### PR TITLE
Team path header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.checkmarx</groupId>
     <artifactId>cx-client-common</artifactId>
-    <version>9.20.SCA-SNAPSHOT</version>
+    <version>9.20.SCA.TEAMPATH-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Checkmarx Client</name>
     <description>Enables web services access Checkmarx SAST and OSA scan.</description>

--- a/src/main/java/com/cx/restclient/CxShragaClient.java
+++ b/src/main/java/com/cx/restclient/CxShragaClient.java
@@ -116,6 +116,7 @@ public class CxShragaClient {
             getCxVersion();
             login();
             resolveTeam();
+            httpClient.setTeamPathHeader(this.teamPath);
             if (config.getSastEnabled()) {
                 resolvePreset();
             }
@@ -210,6 +211,7 @@ public class CxShragaClient {
     }
 
     private CxArmConfig getCxARMConfig() throws IOException, CxClientException {
+        httpClient.setTeamPathHeader(this.teamPath);
         return httpClient.getRequest(CX_ARM_URL, CONTENT_TYPE_APPLICATION_JSON_V1, CxArmConfig.class, 200, "CxARM URL", false);
     }
 
@@ -223,7 +225,10 @@ public class CxShragaClient {
 
     public List<Project> getAllProjects() throws IOException, CxClientException {
         List<Project> projects = null;
+        List<Team> teamList = getTeamList();
+
         try {
+            httpClient.setTeamPathHeader(this.teamPath);
             projects = (List<Project>) httpClient.getRequest(SAST_GET_All_PROJECTS, CONTENT_TYPE_APPLICATION_JSON_V1, Project.class, 200, "all projects", true);
         } catch (HttpResponseException ex) {
             if (ex.getStatusCode() != 404) {
@@ -316,19 +321,36 @@ public class CxShragaClient {
         throw new CxClientException("Could not resolve preset ID from preset name: " + presetName);
     }
 
-    public List<Team> getTeamList() throws IOException, CxClientException {
+    private List<Team> populateTeamList() throws IOException, CxClientException {
         return (List<Team>) httpClient.getRequest(CXTEAMS, CONTENT_TYPE_APPLICATION_JSON_V1, Team.class, 200, "team list", true);
     }
 
+    public List<Team> getTeamList() throws IOException, CxClientException {
+
+        List<Team> teamList = populateTeamList();
+        //If there is no chosen teamPath, just add first one from the teams list as default
+        if(StringUtils.isEmpty(this.teamPath) && teamList!=null && !teamList.isEmpty()){
+            this.teamPath= teamList.get(0).getFullName();
+        }
+        httpClient.setTeamPathHeader(this.teamPath);
+        log.debug("getTeamList setTeamPathHeader " + this.teamPath);
+        return  teamList;
+    }
+
     public Preset getPresetById(int presetId) throws IOException, CxClientException {
+        httpClient.setTeamPathHeader(this.teamPath);
         return httpClient.getRequest(CXPRESETS + "/" + presetId, CONTENT_TYPE_APPLICATION_JSON_V1, Preset.class, 200, "preset by id", false);
     }
 
     public List<Preset> getPresetList() throws IOException, CxClientException {
+        List<Team> teamList = getTeamList();
+        httpClient.setTeamPathHeader(this.teamPath);
         return (List<Preset>) httpClient.getRequest(CXPRESETS, CONTENT_TYPE_APPLICATION_JSON_V1, Preset.class, 200, "preset list", true);
     }
 
     public List<CxNameObj> getConfigurationSetList() throws IOException, CxClientException {
+        List<Team> teamList = getTeamList();
+        httpClient.setTeamPathHeader(this.teamPath);
         return (List<CxNameObj>) httpClient.getRequest(SAST_ENGINE_CONFIG, CONTENT_TYPE_APPLICATION_JSON_V1, CxNameObj.class, 200, "engine configurations", true);
     }
 
@@ -407,6 +429,7 @@ public class CxShragaClient {
         String projectNamePath = SAST_GET_PROJECT.replace("{name}", projectName).replace("{teamId}", teamId);
         List<Project> projects = null;
         try {
+            httpClient.setTeamPathHeader(this.teamPath);
             projects = (List<Project>) httpClient.getRequest(projectNamePath, CONTENT_TYPE_APPLICATION_JSON_V1, Project.class, 200, "project by name: " + projectName, true);
         } catch (CxHTTPClientException ex) {
             if (ex.getStatusCode() != 404) {
@@ -418,6 +441,7 @@ public class CxShragaClient {
 
     private Project createNewProject(CreateProjectRequest request) throws CxClientException, IOException {
         String json = convertToJson(request);
+        httpClient.setTeamPathHeader(this.teamPath);
         StringEntity entity = new StringEntity(json, StandardCharsets.UTF_8);
         return httpClient.postRequest(CREATE_PROJECT, CONTENT_TYPE_APPLICATION_JSON_V1, entity, Project.class, 201, "create new project: " + request.getName());
     }

--- a/src/main/java/com/cx/restclient/CxShragaClient.java
+++ b/src/main/java/com/cx/restclient/CxShragaClient.java
@@ -41,7 +41,7 @@ public class CxShragaClient {
     private Logger log;
     private CxScanConfig config;
     private long projectId;
-
+    private String teamPath;
     private CxSASTClient sastClient;
 
     private long sastScanId;
@@ -342,6 +342,7 @@ public class CxShragaClient {
             config.setTeamId(getTeamIdByName(config.getTeamPath()));
         }
         printTeamPath();
+        httpClient.setTeamPathHeader(this.teamPath);
     }
 
     private void resolveCxARMUrl() throws CxClientException {
@@ -372,11 +373,11 @@ public class CxShragaClient {
 
     private void printTeamPath() {
         try {
-            String teamPath = config.getTeamPath();
-            if (teamPath == null) {
-                teamPath = getTeamNameById(config.getTeamId());
+            this.teamPath = config.getTeamPath();
+            if (this.teamPath == null) {
+                this.teamPath = getTeamNameById(config.getTeamId());
             }
-            log.info("full team path: " + teamPath);
+            log.info("full team path: " + this.teamPath);
         } catch (Exception e) {
         }
     }

--- a/src/main/java/com/cx/restclient/common/CxPARAM.java
+++ b/src/main/java/com/cx/restclient/common/CxPARAM.java
@@ -31,6 +31,6 @@ public abstract class CxPARAM {
     public static final String DENY_NEW_PROJECT_ERROR = "Creation of the new project [{projectName}] is not authorized. " +
             "Please use an existing project. \nYou can enable the creation of new projects by disabling" + "" +
             " the Deny new Checkmarx projects creation checkbox in the Checkmarx plugin global settings.\n";
-
+    public static final String TEAM_PATH = "cxTeamPath";
 
 }

--- a/src/main/java/com/cx/restclient/httpClient/CxHttpClient.java
+++ b/src/main/java/com/cx/restclient/httpClient/CxHttpClient.java
@@ -398,6 +398,7 @@ public class CxHttpClient {
 
         try {
             httpMethod.addHeader(ORIGIN_HEADER, cxOrigin);
+            log.debug("request setTeamPathHeader " + this.teamPath);
             httpMethod.addHeader(TEAM_PATH, this.teamPath);
             if (token != null) {
                 httpMethod.addHeader(HttpHeaders.AUTHORIZATION, token.getToken_type() + " " + token.getAccess_token());

--- a/src/main/java/com/cx/restclient/httpClient/CxHttpClient.java
+++ b/src/main/java/com/cx/restclient/httpClient/CxHttpClient.java
@@ -94,6 +94,7 @@ public class CxHttpClient {
     private String cxOrigin;
     private Boolean useSSo;
     private LoginSettings lastLoginSettings;
+    private String teamPath;
     private CookieStore cookieStore = new BasicCookieStore();
 
     public CxHttpClient(String rootUri, String origin, boolean disableSSLValidation, boolean isSSO, String refreshToken,
@@ -381,6 +382,10 @@ public class CxHttpClient {
         request(patch, contentType, entity, null, expectStatus, failedMsg, false, true);
     }
 
+    public void setTeamPathHeader(String teamPath){
+        this.teamPath = teamPath;
+    }
+
     private <T> T request(HttpRequestBase httpMethod, String contentType, HttpEntity entity, Class<T> responseType, int expectStatus, String failedMsg, boolean isCollection, boolean retry) throws IOException, CxClientException {
         if (contentType != null) {
             httpMethod.addHeader("Content-type", contentType);
@@ -393,6 +398,7 @@ public class CxHttpClient {
 
         try {
             httpMethod.addHeader(ORIGIN_HEADER, cxOrigin);
+            httpMethod.addHeader(TEAM_PATH, this.teamPath);
             if (token != null) {
                 httpMethod.addHeader(HttpHeaders.AUTHORIZATION, token.getToken_type() + " " + token.getAccess_token());
             }


### PR DESCRIPTION
I have updated even more requests to contain the team path header.
Concern for code review - now each getPresets and getProjects also goes to getTeamList.
so now we are fetching all teams list 3 times and not once as it was before.
On large scale organizations(like 30000 teams) it possibly can cause performance issue. 
Didn't found elegant way to do it, will happy to get your feedback about it.
Thank you!