### PR TITLE
Added login API support for AST

### DIFF
--- a/Jenkinsfile-CI-CD
+++ b/Jenkinsfile-CI-CD
@@ -179,7 +179,7 @@ pipeline {
                         stage('Pull Automation Code') {
                             steps {
                                 dir("${workspace}/8.9/Checkmarx-System-Test") {
-                                    git branch: automationBranch, credentialsId: '15f8e7b7-6ce7-44c0-b151-84f99ffa7aed', poll: false, url: 'http://tfs2013:8080/tfs/DefaultCollection/Automation/_git/Checkmarx-System-Test'
+                                    git branch: "${env.automationBranch}", credentialsId: '15f8e7b7-6ce7-44c0-b151-84f99ffa7aed', poll: false, url: 'http://tfs2013:8080/tfs/DefaultCollection/Automation/_git/Checkmarx-System-Test'
                                     sh "cp -r ../../../env ."
                                     sh "sed -e 's/<CxSastIpAddress>/${ipAddress89}/g' -i ./env/topology.xml"
                                 }
@@ -253,7 +253,7 @@ pipeline {
                         stage('Pull Automation Code') {
                             steps {
                                 dir("${workspace}/9.0/Checkmarx-System-Test") {
-                                    git branch: automationBranch, credentialsId: '15f8e7b7-6ce7-44c0-b151-84f99ffa7aed', poll: false, url: 'http://tfs2013:8080/tfs/DefaultCollection/Automation/_git/Checkmarx-System-Test'
+                                    git branch: "${env.automationBranch}", credentialsId: '15f8e7b7-6ce7-44c0-b151-84f99ffa7aed', poll: false, url: 'http://tfs2013:8080/tfs/DefaultCollection/Automation/_git/Checkmarx-System-Test'
                                     sh "cp -r ../../../env ."
                                     sh "sed -e 's/<CxSastIpAddress>/${ipAddress90}/g' -i ./env/topology.xml"
                                 }
@@ -327,7 +327,7 @@ pipeline {
                         stage('Pull Automation Code') {
                             steps {
                                 dir("${workspace}/9.2/Checkmarx-System-Test") {
-                                    git branch: automationBranch, credentialsId: '15f8e7b7-6ce7-44c0-b151-84f99ffa7aed', poll: false, url: 'http://tfs2013:8080/tfs/DefaultCollection/Automation/_git/Checkmarx-System-Test'
+                                    git branch: "${env.automationBranch}", credentialsId: '15f8e7b7-6ce7-44c0-b151-84f99ffa7aed', poll: false, url: 'http://tfs2013:8080/tfs/DefaultCollection/Automation/_git/Checkmarx-System-Test'
                                     sh "cp -r ../../../env ."
                                     sh "sed -e 's/<CxSastIpAddress>/${ipAddress92}/g' -i ./env/topology.xml"
                                 }
@@ -401,7 +401,7 @@ pipeline {
                         stage('Pull Automation Code') {
                             steps {
                                 dir("${workspace}/9.3/Checkmarx-System-Test") {
-                                    git branch: automationBranch, credentialsId: '15f8e7b7-6ce7-44c0-b151-84f99ffa7aed', poll: false, url: 'http://tfs2013:8080/tfs/DefaultCollection/Automation/_git/Checkmarx-System-Test'
+                                    git branch: "${env.automationBranch}", credentialsId: '15f8e7b7-6ce7-44c0-b151-84f99ffa7aed', poll: false, url: 'http://tfs2013:8080/tfs/DefaultCollection/Automation/_git/Checkmarx-System-Test'
                                     sh "cp -r ../../../env ."
                                     sh "sed -e 's/<CxSastIpAddress>/${ipAddress93}/g' -i ./env/topology.xml"
                                 }

--- a/src/main/java/com/cx/restclient/ast/AstClient.java
+++ b/src/main/java/com/cx/restclient/ast/AstClient.java
@@ -182,4 +182,9 @@ public abstract class AstClient {
         }
         return result;
     }
+
+    protected void handleInitError(IOException e) {
+        String message = String.format("Failed to init %s client.", getScannerDisplayName());
+        throw new CxClientException(message, e);
+    }
 }

--- a/src/main/java/com/cx/restclient/ast/AstSastClient.java
+++ b/src/main/java/com/cx/restclient/ast/AstSastClient.java
@@ -53,6 +53,7 @@ public class AstSastClient extends AstClient implements Scanner {
     private static final int NO_FINDINGS_CODE = 4004;
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String API_VERSION = "*/*; version=0.1";
 
     private String scanId;
 
@@ -66,6 +67,7 @@ public class AstSastClient extends AstClient implements Scanner {
         String normalizedUrl = StringUtils.stripEnd(astConfig.getApiUrl(), "/");
 
         httpClient = createHttpClient(normalizedUrl);
+        httpClient.addCustomHeader(HttpHeaders.ACCEPT, API_VERSION);
     }
 
     @Override

--- a/src/main/java/com/cx/restclient/ast/AstSastClient.java
+++ b/src/main/java/com/cx/restclient/ast/AstSastClient.java
@@ -95,9 +95,10 @@ public class AstSastClient extends AstClient implements Scanner {
     }
 
     private ClientType getClientType() {
+        AstSastConfig astConfig = config.getAstSastConfig();
         return ClientType.builder()
-                .clientId("CxFlow")
-                .clientSecret(config.getAstSastConfig().getClientSecret())
+                .clientId(astConfig.getClientId())
+                .clientSecret(astConfig.getClientSecret())
                 .scopes("ast-api")
                 .grantType("client_credentials")
                 .build();

--- a/src/main/java/com/cx/restclient/ast/AstSastClient.java
+++ b/src/main/java/com/cx/restclient/ast/AstSastClient.java
@@ -21,7 +21,6 @@ import com.cx.restclient.dto.LoginSettings;
 import com.cx.restclient.dto.Results;
 import com.cx.restclient.dto.ScannerType;
 import com.cx.restclient.dto.SourceLocationType;
-import com.cx.restclient.dto.TokenLoginResponse;
 import com.cx.restclient.dto.scansummary.Severity;
 import com.cx.restclient.exception.CxClientException;
 import com.cx.restclient.exception.CxHTTPClientException;
@@ -36,7 +35,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.auth.AUTH;
 import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 
@@ -82,11 +80,7 @@ public class AstSastClient extends AstClient implements Scanner {
         try {
             ClientType clientType = getClientType();
             LoginSettings settings = getLoginSettings(clientType);
-
-            TokenLoginResponse response = httpClient.generateToken(settings);
-
-            String headerValue = String.format("Bearer %s", response.getAccess_token());
-            httpClient.addCustomHeader(AUTH.WWW_AUTH_RESP, headerValue);
+            httpClient.login(settings);
         } catch (IOException e) {
             super.handleInitError(e);
         }

--- a/src/main/java/com/cx/restclient/ast/AstScaClient.java
+++ b/src/main/java/com/cx/restclient/ast/AstScaClient.java
@@ -149,10 +149,12 @@ public class AstScaClient extends AstClient implements Scanner {
 
     @Override
     public void init() {
+        log.debug("Initializing {} client.", getScannerDisplayName());
         try {
             login();
         } catch (IOException e) {
-            throw new CxClientException("Failed to init CxSCA Client.", e);
+            String message = String.format("Failed to init %s client.", getScannerDisplayName());
+            throw new CxClientException(message, e);
         }
     }
 
@@ -467,14 +469,13 @@ public class AstScaClient extends AstClient implements Scanner {
         log.info("Logging into {}", getScannerDisplayName());
         AstScaConfig scaConfig = config.getAstScaConfig();
 
-        LoginSettings settings = new LoginSettings();
-
         String acUrl = scaConfig.getAccessControlUrl();
-
-        settings.setAccessControlBaseUrl(UrlUtils.parseURLToString(acUrl, CxPARAM.AUTHENTICATION));
-        settings.setUsername(scaConfig.getUsername());
-        settings.setPassword(scaConfig.getPassword());
-        settings.setTenant(scaConfig.getTenant());
+        LoginSettings settings = LoginSettings.builder()
+                .accessControlBaseUrl(UrlUtils.parseURLToString(acUrl, CxPARAM.AUTHENTICATION))
+                .username(scaConfig.getUsername())
+                .password(scaConfig.getPassword())
+                .tenant(scaConfig.getTenant())
+                .build();
 
         ClientTypeResolver resolver = new ClientTypeResolver();
         ClientType clientType = resolver.determineClientType(acUrl);

--- a/src/main/java/com/cx/restclient/ast/AstScaClient.java
+++ b/src/main/java/com/cx/restclient/ast/AstScaClient.java
@@ -153,8 +153,7 @@ public class AstScaClient extends AstClient implements Scanner {
         try {
             login();
         } catch (IOException e) {
-            String message = String.format("Failed to init %s client.", getScannerDisplayName());
-            throw new CxClientException(message, e);
+            super.handleInitError(e);
         }
     }
 

--- a/src/main/java/com/cx/restclient/ast/AstScaClient.java
+++ b/src/main/java/com/cx/restclient/ast/AstScaClient.java
@@ -4,6 +4,7 @@ import com.cx.restclient.ast.dto.common.*;
 import com.cx.restclient.ast.dto.sca.*;
 import com.cx.restclient.ast.dto.sca.report.Package;
 import com.cx.restclient.ast.dto.sca.report.*;
+import com.cx.restclient.common.CxPARAM;
 import com.cx.restclient.common.Scanner;
 import com.cx.restclient.common.UrlUtils;
 import com.cx.restclient.configuration.CxScanConfig;
@@ -470,7 +471,7 @@ public class AstScaClient extends AstClient implements Scanner {
 
         String acUrl = scaConfig.getAccessControlUrl();
 
-        settings.setAccessControlBaseUrl(acUrl);
+        settings.setAccessControlBaseUrl(UrlUtils.parseURLToString(acUrl, CxPARAM.AUTHENTICATION));
         settings.setUsername(scaConfig.getUsername());
         settings.setPassword(scaConfig.getPassword());
         settings.setTenant(scaConfig.getTenant());

--- a/src/main/java/com/cx/restclient/ast/ClientTypeResolver.java
+++ b/src/main/java/com/cx/restclient/ast/ClientTypeResolver.java
@@ -42,7 +42,11 @@ public class ClientTypeResolver {
         String clientSecret = scopesToUse.equals(scopesForOnPremAuth) ? ClientType.RESOURCE_OWNER.getClientSecret() : "";
 
         String scopesForRequest = String.join(" ", scopesToUse);
-        return new ClientType(ClientType.RESOURCE_OWNER.getClientId(), scopesForRequest, clientSecret);
+
+        return ClientType.builder().clientId(ClientType.RESOURCE_OWNER.getClientId())
+                .scopes(scopesForRequest)
+                .clientSecret(clientSecret)
+                .build();
     }
 
     private Set<String> getScopesForAuth(Set<String> supportedScopes) {

--- a/src/main/java/com/cx/restclient/ast/dto/common/ScanStatus.java
+++ b/src/main/java/com/cx/restclient/ast/dto/common/ScanStatus.java
@@ -3,9 +3,8 @@ package com.cx.restclient.ast.dto.common;
 public enum ScanStatus {
     // Some of the statuses are not used in code, but they help to prevent the "unknown status" warnings.
     CANCELED,
+    QUEUED,
+    RUNNING,
     COMPLETED,
-    CREATED,
-    FAILED,
-    PENDING,
-    RUNNING
+    FAILED
 }

--- a/src/main/java/com/cx/restclient/ast/dto/sast/AstSastConfig.java
+++ b/src/main/java/com/cx/restclient/ast/dto/sast/AstSastConfig.java
@@ -13,7 +13,7 @@ import java.io.Serializable;
 @Setter
 @NoArgsConstructor
 public class AstSastConfig extends ASTConfig implements Serializable  {
-    private String accessToken;
+    private String clientSecret;
     private String presetName;
     private boolean incremental;
 

--- a/src/main/java/com/cx/restclient/ast/dto/sast/AstSastConfig.java
+++ b/src/main/java/com/cx/restclient/ast/dto/sast/AstSastConfig.java
@@ -14,6 +14,7 @@ import java.io.Serializable;
 @NoArgsConstructor
 public class AstSastConfig extends ASTConfig implements Serializable  {
     private String clientSecret;
+    private String clientId;
     private String presetName;
     private boolean incremental;
 

--- a/src/main/java/com/cx/restclient/dto/LoginSettings.java
+++ b/src/main/java/com/cx/restclient/dto/LoginSettings.java
@@ -1,6 +1,8 @@
 package com.cx.restclient.dto;
 
 import com.cx.restclient.osa.dto.ClientType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.apache.http.cookie.Cookie;
 
@@ -8,13 +10,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class LoginSettings {
     private String accessControlBaseUrl;
     private String username;
     private String password;
     private CharSequence tenant;
     private String refreshToken;
-    private List<Cookie> sessionCookies = new ArrayList<>();
+    private final List<Cookie> sessionCookies = new ArrayList<>();
     private String version;
 
     // TODO: find a way to use a single client type here.

--- a/src/main/java/com/cx/restclient/httpClient/CxHttpClient.java
+++ b/src/main/java/com/cx/restclient/httpClient/CxHttpClient.java
@@ -117,7 +117,7 @@ public class CxHttpClient {
         setSSLTls("TLSv1.2", log);
         SSLContextBuilder builder = new SSLContextBuilder();
         SSLConnectionSocketFactory sslConnectionSocketFactory=null;
-        Registry<ConnectionSocketFactory> registry=null;
+        Registry<ConnectionSocketFactory> registry;
         PoolingHttpClientConnectionManager cm=null;
         if (disableSSLValidation) {
             try {
@@ -229,7 +229,7 @@ public class CxHttpClient {
             } else {
                 token = ssoLogin();
                 // Don't delete this print, it is being used on VS Code plugin
-                System.out.println(String.format("Access Token: %s", token.getAccess_token()));
+                System.out.printf("Access Token: %s%n", token.getAccess_token());
             }
         } else {
             token = generateToken(settings);
@@ -280,7 +280,7 @@ public class CxHttpClient {
 
         // Don't delete these prints, they are being used on VS Code plugin
         System.out.println(CSRF_TOKEN_HEADER + ": " + csrfToken);
-        System.out.println(String.format("cookie: CXCSRFToken=%s; cxCookie=%s", csrfToken, cxCookie));
+        System.out.printf("cookie: CXCSRFToken=%s; cxCookie=%s%n", csrfToken, cxCookie);
 
         apacheClient = cb.setDefaultHeaders(headers).build();
     }
@@ -360,8 +360,7 @@ public class CxHttpClient {
 
     public TokenLoginResponse generateToken(LoginSettings settings) throws IOException, CxClientException {
         UrlEncodedFormEntity requestEntity = generateUrlEncodedFormEntity(settings);
-        String fullUrl = UrlUtils.parseURLToString(settings.getAccessControlBaseUrl(), AUTHENTICATION);
-        HttpPost post = new HttpPost(fullUrl);
+        HttpPost post = new HttpPost(settings.getAccessControlBaseUrl());
         try {
             return request(post, ContentType.APPLICATION_FORM_URLENCODED.toString(), requestEntity,
                     TokenLoginResponse.class, HttpStatus.SC_OK, "authenticate", false, false);
@@ -379,8 +378,7 @@ public class CxHttpClient {
 
     private TokenLoginResponse getAccessTokenFromRefreshToken(LoginSettings settings) throws IOException, CxClientException {
         UrlEncodedFormEntity requestEntity = generateTokenFromRefreshEntity(settings);
-        String fullUrl = UrlUtils.parseURLToString(settings.getAccessControlBaseUrl(), AUTHENTICATION);
-        HttpPost post = new HttpPost(fullUrl);
+        HttpPost post = new HttpPost(settings.getAccessControlBaseUrl());
         try {
             return request(post, ContentType.APPLICATION_FORM_URLENCODED.toString(), requestEntity,
                     TokenLoginResponse.class, HttpStatus.SC_OK, "authenticate", false, false);

--- a/src/main/java/com/cx/restclient/osa/dto/ClientType.java
+++ b/src/main/java/com/cx/restclient/osa/dto/ClientType.java
@@ -1,38 +1,26 @@
 package com.cx.restclient.osa.dto;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
 public class ClientType {
 
     public static final ClientType RESOURCE_OWNER = new ClientType("resource_owner_client",
             "sast_rest_api cxarm_api",
-            "014DF517-39D1-4453-B7B3-9930C563627C");
+            "014DF517-39D1-4453-B7B3-9930C563627C",
+            null);
 
     public static final ClientType CLI = new ClientType("cli_client",
             "sast_rest_api offline_access",
-            "B9D84EA8-E476-4E83-A628-8A342D74D3BD");
+            "B9D84EA8-E476-4E83-A628-8A342D74D3BD",
+            null);
 
     private String clientId;
     private String scopes;
     private String clientSecret;
-
-    public ClientType(String clientId, String scopes, String clientSecret) {
-        this.clientId = clientId;
-        this.scopes = scopes;
-        this.clientSecret = clientSecret;
-    }
-
-    public String getClientSecret() {
-        return clientSecret;
-    }
-
-    public String getScopes() {
-        return scopes;
-    }
-
-    public void setScopes(String scopes) {
-        this.scopes = scopes;
-    }
-
-    public String getClientId() {
-        return clientId;
-    }
+    private String grantType;
 }

--- a/src/main/java/com/cx/restclient/sast/utils/LegacyClient.java
+++ b/src/main/java/com/cx/restclient/sast/utils/LegacyClient.java
@@ -88,7 +88,7 @@ public abstract class LegacyClient {
             teamPath =  teamList.get(0).getFullName();
         }
         httpClient.setTeamPathHeader(teamPath);
-        log.debug(" setTeamPathHeader " + teamPath);
+        log.debug(String.format(" setTeamPathHeader %s", teamPath));
         return teamPath;
     }
     
@@ -216,16 +216,16 @@ public abstract class LegacyClient {
     }
 
     public LoginSettings getDefaultLoginSettings() throws MalformedURLException {
-        LoginSettings result = new LoginSettings();
-
         String baseUrl = UrlUtils.parseURLToString(config.getUrl(), DEFAULT_AUTH_API_PATH);
-        result.setAccessControlBaseUrl(baseUrl);
+        LoginSettings result = LoginSettings.builder()
+                .accessControlBaseUrl(baseUrl)
+                .username(config.getUsername())
+                .password(config.getPassword())
+                .clientTypeForPasswordAuth(ClientType.RESOURCE_OWNER)
+                .clientTypeForRefreshToken(ClientType.CLI)
+                .build();
 
-        result.setUsername(config.getUsername());
-        result.setPassword(config.getPassword());
         result.getSessionCookies().addAll(config.getSessionCookie());
-        result.setClientTypeForPasswordAuth(ClientType.RESOURCE_OWNER);
-        result.setClientTypeForRefreshToken(ClientType.CLI);
 
         return result;
     }
@@ -243,7 +243,7 @@ public abstract class LegacyClient {
             for (EngineConfiguration engineConfiguration : engineConfigurations) {
                 if (engineConfiguration.getName().equalsIgnoreCase(config.getEngineConfigurationName())) {
                     config.setEngineConfigurationId(engineConfiguration.getId());
-                    log.info("Engine configuration: \"" + config.getEngineConfigurationName() + "\" was validated in server");
+                    log.info(String.format("Engine configuration: \"%s\" was validated in server", config.getEngineConfigurationName()));
                 }
             }
             if (config.getEngineConfigurationId() == null) {
@@ -281,8 +281,6 @@ public abstract class LegacyClient {
         }
         
         printTeamPath();
-        
-        //httpClient.setTeamPathHeader(this.teamPath);
     }
 
     public String getTeamIdByName(String teamName) throws CxClientException, IOException {
@@ -348,8 +346,9 @@ public abstract class LegacyClient {
             if (presetName == null) {
                 presetName = getPresetById(config.getPresetId()).getName();
             }
-            log.info("preset name: " + presetName);
+            log.info(String.format("preset name: %s", presetName));
         } catch (Exception e) {
+            log.warn("Error getting preset name.");
         }
     }
 
@@ -364,8 +363,9 @@ public abstract class LegacyClient {
             if (this.teamPath == null) {
                 this.teamPath = getTeamNameById(config.getTeamId());
             }
-            log.info("full team path: " + this.teamPath);
+            log.info(String.format("full team path: %s", this.teamPath));
         } catch (Exception e) {
+            log.warn("Error getting team path.");
         }
     }
 

--- a/src/main/java/com/cx/restclient/sast/utils/LegacyClient.java
+++ b/src/main/java/com/cx/restclient/sast/utils/LegacyClient.java
@@ -36,7 +36,7 @@ import static com.cx.restclient.sast.utils.SASTParam.*;
  */
 public abstract class LegacyClient {
 
-    private static final String DEFAULT_AUTH_API_PATH = "CxRestApi/auth/";
+    private static final String DEFAULT_AUTH_API_PATH = "CxRestApi/auth/" + AUTHENTICATION;
     protected CxHttpClient httpClient;
     protected CxScanConfig config;
     protected Logger log;
@@ -175,7 +175,7 @@ public abstract class LegacyClient {
     
     
     public String getCxVersion() throws IOException, CxClientException {
-        String version = "";
+        String version;
         try {
             config.setCxVersion(httpClient.getRequest(CX_VERSION, CONTENT_TYPE_APPLICATION_JSON_V1, CxVersion.class, 200, "cx Version", false));
             String hotfix = "";

--- a/src/test/java/com/cx/restclient/general/AstSastTest.java
+++ b/src/test/java/com/cx/restclient/general/AstSastTest.java
@@ -100,8 +100,8 @@ public class AstSastTest extends CommonClientTest {
     private static CxScanConfig getScanConfig() throws MalformedURLException {
         AstSastConfig astConfig = AstSastConfig.builder()
                 .apiUrl(prop("astSast.apiUrl"))
+                .clientSecret(prop("astSast.clientSecret"))
                 .sourceLocationType(SourceLocationType.REMOTE_REPOSITORY)
-                .accessToken(prop("astSast.accessToken"))
                 .build();
 
         RemoteRepositoryInfo repoInfo = new RemoteRepositoryInfo();
@@ -109,7 +109,7 @@ public class AstSastTest extends CommonClientTest {
         repoInfo.setUrl(repoUrl);
         astConfig.setRemoteRepositoryInfo(repoInfo);
         astConfig.setResultsPageSize(10);
-        astConfig.setPresetName("Default");
+        astConfig.setPresetName("Checkmarx Default");
 
         CxScanConfig config = new CxScanConfig();
         config.setAstSastConfig(astConfig);

--- a/src/test/java/com/cx/restclient/general/AstSastTest.java
+++ b/src/test/java/com/cx/restclient/general/AstSastTest.java
@@ -101,6 +101,7 @@ public class AstSastTest extends CommonClientTest {
         AstSastConfig astConfig = AstSastConfig.builder()
                 .apiUrl(prop("astSast.apiUrl"))
                 .clientSecret(prop("astSast.clientSecret"))
+                .clientId("CxFlow")
                 .sourceLocationType(SourceLocationType.REMOTE_REPOSITORY)
                 .build();
 

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -26,4 +26,4 @@ astSca.onPremise.password=mypassword
 astSast.apiUrl=http://example.com
 astSast.remoteRepoUrl.public=http://example.com/my/public-repo.git
 astSast.projectName=ast-sast-test-01
-astSast.accessToken=mytoken
+astSast.clientSecret=mysecret


### PR DESCRIPTION
### Description

Before the change, as a temporary solution, AST-SAST client used a ready-made access token. Such token was generated manually (e.g. in Postman).

After the change, AST-SAST client is able to create access tokens itself. To do this, client ID and client secret need to be provided from the outside (see the AstSastConfig class).

To handle token expiration, the same mechanism is used as in other clients. Suppose AST-SAST client receives HTTP "Unauthorized" status after sending some request. In this case the client assumes that the token has expired. It then tries to re-authenticate with the same client ID and client secret. If the re-authentication attempt fails, the client throws the "CxTokenExpiredException" exception.

### References

User story [218](https://dev.azure.com/CxFlow/CxFlow/_workitems/edit/218/).

### Testing

The test at com.cx.restclient.general.AstSastTest#scan_remotePublicRepo has been updated to reflect the changes.
