### PR TITLE
SCA feature break-the-build implemented

### DIFF
--- a/src/main/java/com/cx/restclient/CxClientDelegator.java
+++ b/src/main/java/com/cx/restclient/CxClientDelegator.java
@@ -132,6 +132,7 @@ public class CxClientDelegator implements Scanner {
 
             OSAResults osaResults = (OSAResults) scanResults.get(ScannerType.OSA);
             SASTResults sastResults = (SASTResults) scanResults.get(ScannerType.SAST);
+            AstScaResults scaResults = (AstScaResults) scanResults.get(ScannerType.AST_SCA);
 
             boolean hasOsaViolations =
                     osaResults != null &&
@@ -143,8 +144,13 @@ public class CxClientDelegator implements Scanner {
             if (sastResults != null && sastResults.getSastPolicies() != null && !sastResults.getSastPolicies().isEmpty()) {
                 hasSastPolicies = true;
             }
+            
+            boolean hasScaViolations = false;
+            if (scaResults != null && scaResults.isPolicyViolated()) {
+            	hasScaViolations = true;
+            }            
 
-            if (!hasSastPolicies && !hasOsaViolations) {
+            if (!hasSastPolicies && !hasOsaViolations && !hasScaViolations) {
                 log.info(PROJECT_POLICY_COMPLIANT_STATUS);
                 log.info(PRINT_LINE);
             } else {
@@ -154,6 +160,9 @@ public class CxClientDelegator implements Scanner {
                 }
                 if (hasOsaViolations) {
                     log.info("OSA violated policies names: {}", getPoliciesNames(osaResults.getOsaPolicies()));
+                }
+                if (hasScaViolations) {
+                    log.info("SCA policies are violated.");
                 }
                 log.info(PRINT_LINE);
             }

--- a/src/main/java/com/cx/restclient/ast/dto/sca/AstScaResults.java
+++ b/src/main/java/com/cx/restclient/ast/dto/sca/AstScaResults.java
@@ -3,6 +3,7 @@ package com.cx.restclient.ast.dto.sca;
 import com.cx.restclient.ast.dto.sca.report.AstScaSummaryResults;
 import com.cx.restclient.ast.dto.sca.report.Finding;
 import com.cx.restclient.ast.dto.sca.report.Package;
+import com.cx.restclient.ast.dto.sca.report.PolicyEvaluation;
 import com.cx.restclient.dto.Results;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,6 +21,7 @@ import java.util.List;
 @AllArgsConstructor
 public class AstScaResults extends Results implements Serializable {
     private String scanId;
+    private String reportId;
     private AstScaSummaryResults summary;
     private String webReportLink;
     private List<Finding> findings;
@@ -27,6 +29,9 @@ public class AstScaResults extends Results implements Serializable {
     private boolean scaResultReady;
     private int nonVulnerableLibraries;
     private int vulnerableAndOutdated;
+    private List<PolicyEvaluation> policyEvaluations;
+    private boolean policyViolated;
+    private boolean breakTheBuild;
 
     public void calculateVulnerableAndOutdatedPackages() {
         int sum;

--- a/src/main/java/com/cx/restclient/ast/dto/sca/report/PolicyAction.java
+++ b/src/main/java/com/cx/restclient/ast/dto/sca/report/PolicyAction.java
@@ -1,0 +1,18 @@
+package com.cx.restclient.ast.dto.sca.report;
+
+import java.io.Serializable;
+
+
+public class PolicyAction implements Serializable {
+	private boolean breakBuild;
+
+	public final boolean isBreakBuild() {
+		return breakBuild;
+	}
+
+	public final void setBreakBuild(boolean breakBuild) {
+		this.breakBuild = breakBuild;
+	}
+	
+	
+}

--- a/src/main/java/com/cx/restclient/ast/dto/sca/report/PolicyEvaluation.java
+++ b/src/main/java/com/cx/restclient/ast/dto/sca/report/PolicyEvaluation.java
@@ -1,0 +1,58 @@
+package com.cx.restclient.ast.dto.sca.report;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+//cannot use lombok because the way boolean members in the APi payload are named
+//Jackson ObjectMapper looks for setter/getter with literally same.
+
+public class PolicyEvaluation implements Serializable {
+	private String id;
+	private String description;
+	private String name;
+	private boolean isViolated;
+	private PolicyAction actions;
+	private List<PolicyRule> rules = new ArrayList<>();
+	
+	public final String getId() {
+		return id;
+	}
+	public final void setId(String id) {
+		this.id = id;
+	}
+	public final String getDescription() {
+		return description;
+	}
+	public final void setDescription(String description) {
+		this.description = description;
+	}
+	public final String getName() {
+		return name;
+	}
+	public final void setName(String name) {
+		this.name = name;
+	}
+	public final boolean getIsViolated() {
+		return isViolated;
+	}	
+	
+	public final void setIsViolated(boolean isViolated) {
+		this.isViolated = isViolated;
+	}
+	
+	public final PolicyAction getActions() {
+		return actions;
+	}
+	public final void setActions(PolicyAction actions) {
+		this.actions = actions;
+	}
+	public final List<PolicyRule> getRules() {
+		return rules;
+	}
+	public final void setRules(List<PolicyRule> rules) {
+		this.rules = rules;
+	}
+
+
+}

--- a/src/main/java/com/cx/restclient/ast/dto/sca/report/PolicyRule.java
+++ b/src/main/java/com/cx/restclient/ast/dto/sca/report/PolicyRule.java
@@ -1,0 +1,30 @@
+package com.cx.restclient.ast.dto.sca.report;
+
+import java.io.Serializable;
+
+public class PolicyRule implements Serializable {
+	private String id;
+	private boolean isViolated;
+	private String name;
+	
+	public final String getId() {
+		return id;
+	}
+	public final void setId(String id) {
+		this.id = id;
+	}
+	public final boolean getIsViolated() {
+		return isViolated;
+	}
+	public final void setIsViolated(boolean isViolated) {
+		this.isViolated = isViolated;
+	}
+	public final String getName() {
+		return name;
+	}
+	public final void setName(String name) {
+		this.name = name;
+	}
+	
+	
+}

--- a/src/main/java/com/cx/restclient/dto/scansummary/ScanSummary.java
+++ b/src/main/java/com/cx/restclient/dto/scansummary/ScanSummary.java
@@ -26,7 +26,7 @@ public class ScanSummary {
 
         addNewResultThresholdErrors(config, sastResults);
 
-        policyViolated = determinePolicyViolation(config, sastResults, osaResults);
+        policyViolated = determinePolicyViolation(config, sastResults, osaResults, scaResults);
     }
 
     @Override
@@ -145,11 +145,11 @@ public class ScanSummary {
         }
     }
 
-    private static boolean determinePolicyViolation(CxScanConfig config, SASTResults sastResults, OSAResults osaResults) {
+    private static boolean determinePolicyViolation(CxScanConfig config, SASTResults sastResults, OSAResults osaResults, AstScaResults scaResults) {
         return config.getEnablePolicyViolations() &&
                 ((osaResults != null &&
                         !osaResults.getOsaPolicies().isEmpty()) ||
-                        (sastResults != null && !sastResults.getSastPolicies().isEmpty()));
+                        (sastResults != null && !sastResults.getSastPolicies().isEmpty())) || (scaResults != null && scaResults.isBreakTheBuild() && scaResults.isPolicyViolated());
     }
 
     private void checkForThresholdError(int value, Integer threshold, ErrorSource source, Severity severity) {

--- a/src/main/resources/common.properties
+++ b/src/main/resources/common.properties
@@ -18,3 +18,6 @@ astSca.packages = riskReports/%s/packages
 astSca.latestScan = riskReports?size=1&projectId=%s
 astSca.webReport = /#/projects/%s/reports/%s
 astSca.resolvingConfigurationApi = /settings/projects/%s/resolving-configuration
+astSca.policyManagementApi= /policy-management/
+astSca.policyManagementEvaliation= policy-evaluation?reportId=%s
+astSca.reportId = scans/%s/riskReportId


### PR DESCRIPTION
### Description
1.  Prints Policy Evaluations
2. Determines if any policy is violated and if any violated policy requires build to break
3. Policy evaluation API requires reportId. Added function for the same.
4. Enhanced ScanSummary to propagate policy violation and break the build to the plugin
5.Some plugin use different function to print policy violations , enhanced same.

### References
#1853

### Testing
1. Tested SCA scan that violates policy with break the build
2. Tested SCA scan that violates policy in more than one policy but one has break the build
3. Tested SCA scan that does violate any SCA policy
4. Tested that policy evaluation and display happens only when config.getEnforcePolicyViolations is enabled

### Checklist

