### PR TITLE
Fix teampath issue in common and hardcoded sensitive information removed 

### DIFF
--- a/Jenkinsfile-CI-CD
+++ b/Jenkinsfile-CI-CD
@@ -491,10 +491,13 @@ pipeline {
                 }
 
                 stage('Maven Central') {
+                    environment {
+                        GNUPG_TOKEN = credentials('gnupg-credentials')
+                    }
                     steps {
                         script {
                             //sh "docker run --rm --name publish-${BUILD_TAG} -v /root/.m2:/root/.m2 -v ${workspace}:/usr/src/cx-common -v /root/.gnupg:/root/.gnupg -w /usr/src/cx-common maven:3.6.1-jdk-8 mvn deploy -P release"
-                            sh "mvn deploy -P release -DskipTests -Dcxcommon.version=${env.cxCommonVersion}"
+                            sh "mvn deploy -P release -DskipTests -Dcxcommon.version=${env.cxCommonVersion} -Dgpg.passphrase=${GNUPG_TOKEN}"
                         }
                     }
                     post {

--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,10 @@
                         <version>1.5</version>
                         <configuration>
                             <executable>/usr/bin/gpg</executable>
-                            <passphrase>Checkmarx123456</passphrase>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
                         </configuration>
                         <executions>
                             <execution>

--- a/src/main/java/com/cx/restclient/configuration/CxScanConfig.java
+++ b/src/main/java/com/cx/restclient/configuration/CxScanConfig.java
@@ -289,7 +289,9 @@ public class CxScanConfig implements Serializable {
         if (!StringUtils.isEmpty(teamPath) && !teamPath.startsWith("\\") && !teamPath.startsWith(("/"))) {
             teamPath = "/" + teamPath;            
         }
+        if(!StringUtils.isEmpty(teamPath)&& teamPath!=null){
         teamPath = teamPath.replace("\\", "/");
+        }
         this.teamPath = teamPath;
     }
 

--- a/src/main/java/com/cx/restclient/sast/utils/LegacyClient.java
+++ b/src/main/java/com/cx/restclient/sast/utils/LegacyClient.java
@@ -93,12 +93,16 @@ public abstract class LegacyClient {
 
 
     public String configureTeamPath() throws IOException, CxClientException {
-
-        List<Team> teamList = populateTeamList();
-        //If there is no chosen teamPath, just add first one from the teams list as default
-        if (StringUtils.isEmpty(teamPath) && teamList != null && !teamList.isEmpty()) {
-            teamPath = teamList.get(0).getFullName();
-        }
+		if (StringUtils.isEmpty(config.getTeamPath())) {
+			List<Team> teamList = populateTeamList();
+			// If there is no chosen teamPath, just add first one from the teams
+			// list as default
+			if (StringUtils.isEmpty(teamPath) && teamList != null && !teamList.isEmpty()) {
+				teamPath = teamList.get(0).getFullName();
+			}
+		} else {
+			teamPath = config.getTeamPath();
+		}
         httpClient.setTeamPathHeader(teamPath);
         log.debug(String.format(" setTeamPathHeader %s", teamPath));
         return teamPath;


### PR DESCRIPTION
1. Added changes for null pointer exception for team path from the plugins where instead of team path team Id is passed to cx-client-common like in case of Jenkins CX plugin and TeamCity Cx plugin
2. Bug https://dev.azure.com/CxSDLC/SDLC/_workitems/edit/1639 - [Cx-Common] - Hardcoded Sensitive Information in Git Repository