### PR TITLE
Fix for master slave mode any failures in scan, build suceeds

### DIFF
--- a/src/main/java/com/cx/restclient/dto/Results.java
+++ b/src/main/java/com/cx/restclient/dto/Results.java
@@ -1,11 +1,13 @@
 package com.cx.restclient.dto;
 
+import java.io.Serializable;
+
 import com.cx.restclient.exception.CxClientException;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-public abstract class Results {
+public abstract class Results implements Serializable{
     private CxClientException exception;
 }


### PR DESCRIPTION
…s was failing. And it is serialized so as to work in master slave ode if during scan any exception occurs , the exception was not getting added to results object. Hence failTheBuild() in CxScanBuilder class not not making the build fail/unstable . This issue was discovered during defect [AB#2334](https://dev.azure.com/CxSDLC/fc0b9449-79c8-4ff2-bd04-b9e18cf01a53/_workitems/edit/2334). The issue was even if user gives wrong user name and password, the job still continue to be SUCCESS in master slave mode

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change.

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
