### PR TITLE
SCA resolver fixes for linux. CxOrigin double headers fix.

### DIFF
--- a/src/main/java/com/cx/restclient/ast/AstScaClient.java
+++ b/src/main/java/com/cx/restclient/ast/AstScaClient.java
@@ -341,16 +341,15 @@ public class AstScaClient extends AstClient implements Scanner {
     	String pathToResultJSONFile = "";
     	File zipFile = new File("");
         pathToResultJSONFile = getScaResolverResultFilePathFromAdditionalParams(scaConfig.getScaResolverAddParameters());
-
+        log.info("Path to the evidence file" + pathToResultJSONFile);
         int exitCode = SpawnScaResolver.runScaResolver(scaConfig.getPathToScaResolver(), scaConfig.getScaResolverAddParameters(),pathToResultJSONFile);
     	if (exitCode == 0) {
-            log.info("Sca Resolver Evidence File Generated.");
-            log.info("Path of Evidence File" + pathToResultJSONFile);
+            log.info("SCA resolution completed successfully.");            
             File resultFilePath = new File(pathToResultJSONFile);
             zipFile = zipEvidenceFile(resultFilePath);
 
         }else{
-            throw new CxClientException("Error while running sca resolver executable.");
+            throw new CxClientException("Error while running sca resolver executable. Exit code:"+exitCode);
         }
     	return initiateScanForUpload(projectId, FileUtils.readFileToByteArray(zipFile), config.getAstScaConfig());
     }
@@ -435,9 +434,7 @@ public class AstScaClient extends AstClient implements Scanner {
         long maxZipSizeBytes = config.getMaxZipSize() != null ? config.getMaxZipSize() * 1024 * 1024 : MAX_ZIP_SIZE_BYTES;
         
         List<String> paths = new ArrayList <String>();
-        paths.add(filePath.getName());
-        log.info("Paths Variable: " + paths.get(0));
-        
+        paths.add(filePath.getName());               
 
         try (NewCxZipFile zipper = new NewCxZipFile(tempUploadFile, maxZipSizeBytes, log)) {
             zipper.addMultipleFilesToArchive(new File(sourceDir), paths);

--- a/src/main/java/com/cx/restclient/ast/SpawnScaResolver.java
+++ b/src/main/java/com/cx/restclient/ast/SpawnScaResolver.java
@@ -6,6 +6,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+
+import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;
 
 /**
@@ -14,7 +16,7 @@ import org.slf4j.Logger;
 
 public class SpawnScaResolver {
 
-	public static final String SCA_RESOLVER_EXE = "ScaResolver.exe";
+	public static final String SCA_RESOLVER_EXE = "ScaResolver";
 	public static final String OFFLINE = "offline";
 
 	/**
@@ -34,7 +36,12 @@ public class SpawnScaResolver {
 		 */
 		arguments = scaResolverAddParams.split(" ");
 		scaResolverCommand = new String[arguments.length + 2];
-		scaResolverCommand[0] = pathToScaResolver + File.separator + SCA_RESOLVER_EXE;
+		
+		pathToScaResolver = pathToScaResolver + File.separator + SCA_RESOLVER_EXE;
+		if(!SystemUtils.IS_OS_UNIX)
+			pathToScaResolver = pathToScaResolver + ".exe";
+		
+		scaResolverCommand[0] = pathToScaResolver;
 		scaResolverCommand[1] = OFFLINE;
 		for  (int i = 0 ; i < arguments.length ; i++){
 

--- a/src/main/java/com/cx/restclient/httpClient/CxHttpClient.java
+++ b/src/main/java/com/cx/restclient/httpClient/CxHttpClient.java
@@ -513,8 +513,9 @@ public class CxHttpClient implements Closeable {
             }
             ClientType.RESOURCE_OWNER.setScopes("sast_rest_api");
             settings.setClientTypeForPasswordAuth(ClientType.RESOURCE_OWNER);
-            requestEntity = getAuthRequest(settings);
-            return request(post, ContentType.APPLICATION_FORM_URLENCODED.toString(), requestEntity,
+            UrlEncodedFormEntity requestEntityForSecondLoginRetry = getAuthRequest(settings);
+            HttpPost post_1 = new HttpPost(settings.getAccessControlBaseUrl());
+            return request(post_1, ContentType.APPLICATION_FORM_URLENCODED.toString(), requestEntityForSecondLoginRetry,
                     TokenLoginResponse.class, HttpStatus.SC_OK, AUTH_MESSAGE, false, false);
         }
     }


### PR DESCRIPTION
### Description

This fixes sca resolver changes to make it work on linux. This also includes a case where http headers gets added twice.

### References

Bug 252491

### Testing

Tested CLI plugin for sca resolver on both windows and linux 

### Checklist

- [X ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X ] All active GitHub checks for tests, formatting, and security are passing
- [ X] The correct base branch is being used
