### PR TITLE
Fix: SCA Resolver Invocation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.10</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.10.0</version>
+        </dependency>
 
         <!-- API -->
         <dependency>

--- a/src/main/java/com/cx/restclient/ast/AstScaClient.java
+++ b/src/main/java/com/cx/restclient/ast/AstScaClient.java
@@ -74,7 +74,6 @@ import com.cx.restclient.sast.utils.zip.NewCxZipFile;
 import com.cx.restclient.sast.utils.zip.Zipper;
 import com.cx.restclient.sca.dto.CxSCAResolvingConfiguration;
 import com.cx.restclient.sca.utils.CxSCAFileSystemUtils;
-import com.cx.restclient.sca.utils.CxSCAResolverUtils;
 import com.cx.restclient.sca.utils.fingerprints.CxSCAScanFingerprints;
 import com.cx.restclient.sca.utils.fingerprints.FingerprintCollector;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -389,11 +388,16 @@ public class AstScaClient extends AstClient implements Scanner {
      * @param scaResolverAddParams - SCA resolver additional parameters
      * @return - SCA resolver execution result file path.
      */
-    private  String getScaResolverResultFilePathFromAdditionalParams(String scaResolverAddParams) throws ParseException
+    private  String getScaResolverResultFilePathFromAdditionalParams(List<String> scaResolverAddParams) throws ParseException
     {
-        Map<String, String> params = CxSCAResolverUtils.parseArguments(scaResolverAddParams);
+        String pathToEvidenceDir = null;
+        for (int i = 0; i < scaResolverAddParams.size(); i++) {
+            if (scaResolverAddParams.get(i).equals("-r") ||  scaResolverAddParams.get(i).equals("--resolver-result-path")) {
+                pathToEvidenceDir = scaResolverAddParams.get(i + 1);
+                break;
+            }
+        }
 
-        String pathToEvidenceDir = params.getOrDefault("-r", params.get("--resolver-result-path"));
         if (StringUtils.isEmpty(pathToEvidenceDir)) {
             throw new ParseException("Missing -r|--resolver-result-path argument.", 0);
         }

--- a/src/main/java/com/cx/restclient/ast/SpawnScaResolver.java
+++ b/src/main/java/com/cx/restclient/ast/SpawnScaResolver.java
@@ -1,16 +1,12 @@
 package com.cx.restclient.ast;
 
 import com.cx.restclient.exception.CxClientException;
-import com.cx.restclient.sca.utils.CxSCAResolverUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
@@ -33,17 +29,10 @@ public class SpawnScaResolver {
      * @param scaResolverAddParams - Additional parameters for SCA resolver
      * @return
      */
-    protected static int runScaResolver(String pathToScaResolver, String scaResolverAddParams, String pathToResultJSONFile, Logger log)
+    protected static int runScaResolver(String pathToScaResolver, List<String> scaResolverAddParams, String pathToResultJSONFile, Logger log)
             throws CxClientException {
         int exitCode = -100;
         List<String> scaResolverCommand = new ArrayList<>();
-
-        Map<String, String> arguments;
-        try {
-            arguments = CxSCAResolverUtils.parseArguments(scaResolverAddParams);
-        } catch (ParseException e) {
-            throw new CxClientException(e.getMessage());
-        }
 
         if (!SystemUtils.IS_OS_UNIX) {
             //Add "ScaResolver.exe" to cmd command on Windows
@@ -59,11 +48,11 @@ public class SpawnScaResolver {
         log.debug("    " + OFFLINE);
         scaResolverCommand.add(OFFLINE);
 
-        for (Map.Entry<String, String> entry: arguments.entrySet()) {
-            String arg = entry.getKey();
-            String value = entry.getValue();
+        for (int i = 0; i < scaResolverAddParams.size(); i++) {
+            String arg = scaResolverAddParams.get(i);
+            String value = scaResolverAddParams.get(i + 1);
 
-            if (value == null) {
+            if ((value.startsWith("-") && value.length() == 2) || value.startsWith("--")) {
                 log.debug("    " + arg);
                 scaResolverCommand.add(arg);
                 continue;
@@ -83,6 +72,7 @@ public class SpawnScaResolver {
 
             scaResolverCommand.add(arg);
             scaResolverCommand.add(value);
+            i++;
         }
         log.debug("Finished created CMD command");
         try {

--- a/src/main/java/com/cx/restclient/ast/dto/sca/AstScaConfig.java
+++ b/src/main/java/com/cx/restclient/ast/dto/sca/AstScaConfig.java
@@ -44,7 +44,7 @@ public class AstScaConfig extends ASTConfig implements Serializable {
     private Boolean isScaProxy;
 
 	private String pathToScaResolver;
-    private String scaResolverAddParameters;
+    private List<String> scaResolverAddParameters;
 	
     private Map<String,String> envVariables;
     private List<String> configFilePaths;

--- a/src/main/java/com/cx/restclient/sca/utils/CxSCAResolverUtils.java
+++ b/src/main/java/com/cx/restclient/sca/utils/CxSCAResolverUtils.java
@@ -9,6 +9,22 @@ import org.apache.commons.text.StringEscapeUtils;
 
 public class CxSCAResolverUtils {
 
+    public static Map<String, String> shortArgumentsMap() {
+        Map<String, String> args = new HashMap<>();
+        args.put("-a", "--account");
+        args.put("-c", "--config-path");
+        args.put("-e", "--excludes");
+        args.put("-n", "--project-name");
+        args.put("-p", "--password");
+        args.put("-r", "--resolver-result-path");
+        args.put("-s", "--scan-path");
+        args.put("-t", "--project-teams");
+        args.put("-u", "--username");
+        args.put("-v", "--version");
+
+        return Collections.unmodifiableMap(args);
+    }
+
     public static Map<String, String> parseArguments(String text) throws ParseException {
         // Split the provided arguments text on spaces.
         // NOTE: We loose multiple spaces information but that should not be of an issue.
@@ -20,6 +36,7 @@ public class CxSCAResolverUtils {
         }
 
         String[] arguments = text.split("\\s+");
+        Map<String, String> shortArgs = shortArgumentsMap();
 
         int parsePos = 0;    // Keep track of our position in the text for error reporting.
         for (int i = 0; i < arguments.length;) {
@@ -40,6 +57,10 @@ public class CxSCAResolverUtils {
             }
 
             parsePos += arg.length() + 1;
+            if (shortArgs.containsKey(arg)) {
+                arg = shortArgs.get(arg);
+            }
+
             // Complete the value until we reach a new argument.
             for (i++; i < arguments.length; i++) {
                 if ((arguments[i].startsWith("-") && arguments[i].length() == 2) || arguments[i].startsWith("--")) {

--- a/src/main/java/com/cx/restclient/sca/utils/CxSCAResolverUtils.java
+++ b/src/main/java/com/cx/restclient/sca/utils/CxSCAResolverUtils.java
@@ -1,0 +1,69 @@
+package com.cx.restclient.sca.utils;
+
+import java.util.*;
+import java.text.ParseException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
+
+
+public class CxSCAResolverUtils {
+
+    public static Map<String, String> parseArguments(String text) throws ParseException {
+        // Split the provided arguments text on spaces.
+        // NOTE: We loose multiple spaces information but that should not be of an issue.
+        Map<String, String> parsed = new HashMap<>();
+
+        text = text.trim();
+        if (StringUtils.isEmpty(text)) {
+            return parsed;
+        }
+
+        String[] arguments = text.split("\\s+");
+
+        int parsePos = 0;    // Keep track of our position in the text for error reporting.
+        for (int i = 0; i < arguments.length;) {
+            String arg = arguments[i];
+            // The argument value may have spaces. This buffer is used to reconstruct the original value.
+            List<String> valueBuffer = new ArrayList<>();
+
+            // Check that we caught a short (`-x`) or long (`--xxxx`) argument.
+            if (!(arg.startsWith("-") && arg.length() == 2) && !arg.startsWith("--")) {
+                throw new ParseException("Could not parse provided arguments: " + text, parsePos);
+            }
+
+            // Do we have a long argument in the form `--xxxx=XXXXX`?
+            if (arg.contains("=")) {
+                String[] parts = arg.split("=", 2);
+                arg = parts[0];
+                valueBuffer.add(parts[1]);
+            }
+
+            parsePos += arg.length() + 1;
+            // Complete the value until we reach a new argument.
+            for (i++; i < arguments.length; i++) {
+                if ((arguments[i].startsWith("-") && arguments[i].length() == 2) || arguments[i].startsWith("--")) {
+                    break;
+                }
+                valueBuffer.add(arguments[i]);
+            }
+
+            // Reconstruct and unescape the value.
+            String value = null;
+            if (!valueBuffer.isEmpty()) {
+                value = String.join(" ", valueBuffer);
+                parsePos += value.length() + 1;
+
+                // Remove potential enclosing quotes.
+                if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
+                    value = value.substring(1, value.length() - 1);
+                }
+                value = StringEscapeUtils.unescapeXSI(value);
+            }
+
+            parsed.put(arg, value);
+        }
+
+        return parsed;
+    }
+}


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This contribution ensures proper invocation of the SCA Resolver:

* Make sure that arguments are properly parsed.
* Expect a list of arguments instead of a `String`. Arguments parsing a delegated to the user.
* Properly log the output from SCA Resolver.
* Store log files along with the SCA Resolver results.

### Testing

This change change was tested using the Bamboo plugin (pull request to come):

```
simple	25-Nov-2022 16:41:30	Executing SCA Resolver flow.
simple	25-Nov-2022 16:41:30	Path to Sca Resolver: /opt/checkmarx/sca/bin
simple	25-Nov-2022 16:41:30	Path to the evidence file: /srv/data/atlassian/bamboo/local-working-dir/WG-CX-JOB1/.cxscaresolver/.cxsca-results.json
simple	25-Nov-2022 16:41:30	Starting build CMD command
simple	25-Nov-2022 16:41:30	Command: /opt/checkmarx/sca/bin/ScaResolver
simple	25-Nov-2022 16:41:30	    offline
simple	25-Nov-2022 16:41:30	    --log-level Debug
simple	25-Nov-2022 16:41:30	    --cxpassword *************
simple	25-Nov-2022 16:41:30	    --resolver-result-path /srv/data/atlassian/bamboo/local-working-dir/WG-CX-JOB1/.cxscaresolver/.cxsca-results.json
simple	25-Nov-2022 16:41:30	    --sast-result-path /srv/data/atlassian/bamboo/local-working-dir/WG-CX-JOB1/.cxscaresolversast
simple	25-Nov-2022 16:41:30	    --cxserver https://beevehoxcmx10.newextranet.be.tme.com
simple	25-Nov-2022 16:41:30	    --cxprojectname OCD - TEST - WebGoat - Checkmarx - Default Job
simple	25-Nov-2022 16:41:30	    --scan-path /srv/data/atlassian/bamboo/local-working-dir/WG-CX-JOB1
simple	25-Nov-2022 16:41:30	    --project-name OCD - TEST - WebGoat - Checkmarx - Default Job
simple	25-Nov-2022 16:41:30	    --cxuser bamboo
simple	25-Nov-2022 16:41:30	    --config-path /srv/data/atlassian/bamboo/local-working-dir/WG-CX-JOB1/.cxscaresolver/Configuration.ini
simple	25-Nov-2022 16:41:30	Finished created CMD command
simple	25-Nov-2022 16:41:30	Checking that next file has -rwxrwxrwx permissions ls /opt/checkmarx/sca/bin/ScaResolver -ltr
simple	25-Nov-2022 16:41:30	-r-xr-xr-x. 1 root root 83461965 Oct 27 11:34 /opt/checkmarx/sca/bin/ScaResolver
simple	25-Nov-2022 16:41:30	Executing ScaResolver command.
simple	25-Nov-2022 16:41:31	Writing logs to /srv/data/atlassian/bamboo/local-working-dir/WG-CX-JOB1/.cxscaresolver/log
simple	25-Nov-2022 16:41:31	
simple	25-Nov-2022 16:41:31	2022-11-25T16:41:31+01:00 Information	 Program "Tool version: 1.13.4"  
simple	25-Nov-2022 16:41:32	2022-11-25T16:41:31+01:00 Debug	 Program "Command-line arguments: [offline --log-level Debug --cxpassword ************* --resolver-result-path /srv/data/atlassian/bamboo/local-working-dir/WG-CX-JOB1/.cxscaresolver/.cxsca-results.json --sast-result-path /srv/data/atlassian/bamboo/local-working-dir/WG-CX-JOB1/.cxscaresolversast --cxserver https://beevehoxcmx10.newextranet.be.tme.com --cxprojectname OCD - TEST - WebGoat - Checkmarx - Default Job --scan-path /srv/data/atlassian/bamboo/local-working-dir/WG-CX-JOB1 --project-name OCD - TEST - WebGoat - Checkmarx - Default Job --cxuser bamboo --config-path /srv/data/atlassian/bamboo/local-working-dir/WG-CX-JOB1/.cxscaresolver/Configuration.ini ], working directory: /, location: /opt/checkmarx/sca/bin/ScaResolver.dll"  
simple	25-Nov-2022 16:41:32	2022-11-25T16:41:32+01:00 Information	 Program "Starting scan from: /srv/data/atlassian/bamboo/local-working-dir/WG-CX-JOB1"  
simple	25-Nov-2022 16:41:32	2022-11-25T16:41:32+01:00 Information	 Program "Starting project folder scan" {["ScanPath"]="/srv/data/atlassian/bamboo/local-working-dir/WG-CX-JOB1"} [("ScanPath": "/srv/data/atlassian/bamboo/local-working-dir/WG-CX-JOB1")] 
simple	25-Nov-2022 16:41:32	2022-11-25T16:41:32+01:00 Information	 Program "Metric" {["Name"]="ScanTime", ["Value"]=722} [("Name": "ScanTime"), ("Value": 722)] 
simple	25-Nov-2022 16:41:32	2022-11-25T16:41:32+01:00 Debug	 Program "On prem mode enabled, running with local SAST server mode"  
simple	25-Nov-2022 16:41:34	2022-11-25T16:41:32+01:00 Information	 SastProxyProvider "Preparing SAST scan" {["sastScanId"]=4f42582e-f292-44a2-85e4-8b4616c77af6} [("sastScanId": 4f42582e-f292-44a2-85e4-8b4616c77af6)] 
simple	25-Nov-2022 16:41:34	2022-11-25T16:41:34+01:00 Warning	 SastServerProvider "an error occured during GetExploitablePathResultsAsync, proceeding without results" {["sast_scan_url"]="https://beevehoxcmx10.newextranet.be.tme.com", ["on_pre_scan"]=True} [("sast_scan_url": "https://beevehoxcmx10.newextranet.be.tme.com"), ("on_pre_scan": True)] System.Exception: an error occured during GetExploitablePathResultsAsync
simple	25-Nov-2022 16:41:34	 ---> System.Exception: the results for  project 2 do not exists or are too old
simple	25-Nov-2022 16:41:34	   at Lumo.SastCorrelationInfra.SastServerProvider.ValidateScanDate(RestClient client, String authToken, String projectId)
simple	25-Nov-2022 16:41:34	   at Lumo.SastCorrelationInfra.SastServerProvider.ValidateResultExistence(RestClient client, String authToken, String projectId)
simple	25-Nov-2022 16:41:34	   at Lumo.SastCorrelationInfra.SastServerProvider.GetExploitablePathResultsAsync(SastServerSettings settings, String projectId)
simple	25-Nov-2022 16:41:34	   --- End of inner exception stack trace ---
simple	25-Nov-2022 16:41:34	   at Lumo.SastCorrelationInfra.SastServerProvider.GetExploitablePathResultsAsync(SastServerSettings settings, String projectId)
simple	25-Nov-2022 16:41:34	   at Lumo.SastCorrelationInfra.SastServerProvider.TryGetExploitablePathResultsAsync(SastServerSettings settings, Action`1 results)
simple	25-Nov-2022 16:41:34	
simple	25-Nov-2022 16:41:34	2022-11-25T16:41:34+01:00 Warning	 SastProxyProvider "ExecuteResultsOnlyScanAsync failed" {} [] 
simple	25-Nov-2022 16:41:34	2022-11-25T16:41:34+01:00 Information	 Program "Scan Id: 9dc8caca-ae83-4334-ab65-2f81e0af3018"  
simple	25-Nov-2022 16:41:34	
simple	25-Nov-2022 16:41:34	Resolved packages information was saved in the /srv/data/atlassian/bamboo/local-working-dir/WG-CX-JOB1/.cxscaresolver/.cxsca-results.json file.
simple	25-Nov-2022 16:41:34	SCA resolution completed successfully.
```
