### PR TITLE
 9.6 ScanWithSettings V5 is not accepting a zip file if it's a GIT, …

### DIFF
--- a/src/main/java/com/cx/restclient/httpClient/utils/ContentType.java
+++ b/src/main/java/com/cx/restclient/httpClient/utils/ContentType.java
@@ -5,6 +5,8 @@ package com.cx.restclient.httpClient.utils;
  */
 public class ContentType {
     public static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
+    public static final String CONTENT_TYPE_API_VERSION_1_2 = "application/json;v=1.2";
+    public static final String CONTENT_TYPE_API_VERSION_1_1 = "application/json;v=1.1";
     public static final String CONTENT_TYPE_APPLICATION_JSON_V21 = "application/json;v=2.1";
     public static final String CONTENT_TYPE_APPLICATION_JSON_V2 = "application/json;v=2.0";
     public static final String CONTENT_TYPE_APPLICATION_JSON_V1 = "application/json;v=1.0";

--- a/src/test/java/com/cx/restclient/CxSASTClientTest.java
+++ b/src/test/java/com/cx/restclient/CxSASTClientTest.java
@@ -1,0 +1,106 @@
+package com.cx.restclient;
+
+import java.net.MalformedURLException;
+import com.cx.restclient.configuration.CxScanConfig;
+import com.cx.restclient.dto.CxVersion;
+import junit.framework.TestCase;
+
+public class CxSASTClientTest extends TestCase {
+	public void testGetContentTypeAndApiVersionWithValidSastVersionAndSastRetentionRate() throws MalformedURLException {
+		   CxScanConfig config = new CxScanConfig();
+		   CxVersion cxVersion = new CxVersion();
+		   cxVersion.setVersion("9.6");
+		   config.setCxVersion(cxVersion);
+		   String apiName = "SAST_RETENTION_RATE";
+		   config.setEnableDataRetention(true);
+
+		   CxSASTClient cxSASTClient = new CxSASTClient(config, null);
+		   String apiVersion = cxSASTClient.getContentTypeAndApiVersion(config, apiName);
+		   assertEquals("Expected API version for valid SAST version and SAST_RETENTION_RATE", "application/json;v=1.1", apiVersion);
+		}
+   
+   public void testGetContentTypeAndApiVersionWithValidSastVersionAndScanWithSettings() throws MalformedURLException {
+	   CxScanConfig config = new CxScanConfig();
+	   CxVersion cxVersion = new CxVersion();
+	   cxVersion.setVersion("9.6");
+	   config.setCxVersion(cxVersion);
+	   String apiName = "scanWithSettings";
+	   String customFields = "{\"custom1\":\"value1\"}";
+	   config.setCustomFields(customFields);
+	   config.setPostScanActionId(1);
+	   CxSASTClient cxSASTClient = new CxSASTClient(config, null);
+	   String apiVersion = cxSASTClient.getContentTypeAndApiVersion(config, apiName);
+	   assertEquals("Expected API version for valid SAST version and scanWithSettings with custom fields and PostScanActionId", "application/json;v=1.2", apiVersion);
+   }
+
+   public void testGetContentTypeAndApiVersionWithValidSastVersionAndScanWithSettingsCustomFieldsOnly() throws MalformedURLException {
+	   CxScanConfig config = new CxScanConfig();
+	   CxVersion cxVersion = new CxVersion();
+	   cxVersion.setVersion("9.6");
+	   config.setCxVersion(cxVersion);
+	   String apiName = "scanWithSettings";
+	   String customFields = "{\"custom1\":\"value1\"}";
+	   config.setCustomFields(customFields);
+	   config.setPostScanActionId(null); 
+	   CxSASTClient cxSASTClient = new CxSASTClient(config, null);
+	   String apiVersion = cxSASTClient.getContentTypeAndApiVersion(config, apiName);
+	   assertEquals("Expected API version for valid SAST version and scanWithSettings with custom fields only", "application/json;v=1.2", apiVersion);
+   }
+
+   public void testGetContentTypeAndApiVersionWithValidSastVersionAndScanWithSettingsPostScanActionIdOnly() throws MalformedURLException {
+	   CxScanConfig config = new CxScanConfig();
+	   CxVersion cxVersion = new CxVersion();
+	   cxVersion.setVersion("9.6");
+	   config.setCxVersion(cxVersion);
+	   String apiName = "scanWithSettings";
+	   config.setCustomFields(null);
+	   config.setPostScanActionId(1);
+	   CxSASTClient cxSASTClient = new CxSASTClient(config, null);
+	   String apiVersion = cxSASTClient.getContentTypeAndApiVersion(config, apiName);
+	   assertEquals("Expected API version for valid SAST version and scanWithSettings with PostScanActionId only", "application/json;v=1.2", apiVersion);
+   }
+
+   public void testGetContentTypeAndApiVersionWithSastVersionIn92To93RangeAndSastRetentionRate() throws MalformedURLException {
+       CxScanConfig config = new CxScanConfig();
+       CxVersion cxVersion = new CxVersion();
+       cxVersion.setVersion("9.3.5");
+       config.setCxVersion(cxVersion);
+       String apiName = "SAST_RETENTION_RATE";
+       CxSASTClient cxSASTClient = new CxSASTClient(config, null);
+       String apiVersion = cxSASTClient.getContentTypeAndApiVersion(config, apiName);
+       assertEquals("Expected API version for SAST version in the 9.2 to 9.3 range and SAST_RETENTION_RATE", "application/json;v=1.0", apiVersion);
+   }
+   
+   public void testGetContentTypeAndApiVersionWithNullSastVersion() throws MalformedURLException {
+       CxScanConfig config = new CxScanConfig();
+       CxVersion cxVersion = new CxVersion();
+       cxVersion.setVersion(null);
+       config.setCxVersion(cxVersion);
+       String apiName = "SAST_RETENTION_RATE";
+       CxSASTClient cxSASTClient = new CxSASTClient(config, null);
+       String apiVersion = cxSASTClient.getContentTypeAndApiVersion(config, apiName);
+       assertEquals("Expected API version when SAST version is null", "application/json;v=1.0", apiVersion);
+   }
+
+   public void testGetContentTypeAndApiVersionWithInvalidSastVersion() throws MalformedURLException {
+       CxScanConfig config = new CxScanConfig();
+       CxVersion cxVersion = new CxVersion();
+       cxVersion.setVersion("9.1.5"); 
+       config.setCxVersion(cxVersion);
+       String apiName = "SAST_RETENTION_RATE";
+       CxSASTClient cxSASTClient = new CxSASTClient(config, null);
+       String apiVersion = cxSASTClient.getContentTypeAndApiVersion(config, apiName);
+       assertEquals("Expected default API version for an invalid SAST version", "application/json;v=1.0", apiVersion);
+   }
+
+   public void testGetContentTypeAndApiVersionWithUnknownApiName() throws MalformedURLException {
+       CxScanConfig config = new CxScanConfig();
+       CxVersion cxVersion = new CxVersion();
+       cxVersion.setVersion("9.4.1");
+       config.setCxVersion(cxVersion);
+       String apiName = "createScanReport"; 
+       CxSASTClient cxSASTClient = new CxSASTClient(config, null);
+       String apiVersion = cxSASTClient.getContentTypeAndApiVersion(config, apiName);
+       assertEquals("Expected default API version for an unknown API name", "application/json;v=1.0", apiVersion);
+   }
+}


### PR DESCRIPTION
…SVN, TFS or a Perforce project

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

-AvoidDuplicateProjectScans parameter : 
Sample command: 
runCxConsole.cmd Scan -v -ProjectName "CxServer/dupProjTest2" -TrustedCertificates -CxServer https://sast94.cxquality.com/ -cxuser admin@cx -cxpassword Cx123456! -LocationType folder -LocationPath "C:\CLIPlugin\GitRepo\JavaVulnerableLabE" -preset "Checkmarx Default" -AvoidDuplicateProjectScans
Expected behavior : when this parameter is used and a sast scan is run simultaneously on two cmd, using same project name, one of the scans should happen successfully, on the other prompt it should throw the error :  
CLI process terminated, error: com.cx.restclient.exception.CxClientException: Avoid duplicate project scans in queue.
   avoidDuplicateProjectScans : true in cx.config
Sample command:
runCxConsole.cmd Scan -ProjectName "CxServer/SP/Checkmarx/ConfigAsCodeDupScan1.5" -CxServer https://sast94.cxquality.com/ -cxuser admin@cx -cxpassword Cx123456! -LocationType folder -LocationPath "C:\CLIPlugin\GitRepo\JavaVulnerableLabE" -preset "Checkmarx Default" -configascode
Expected Behivior : Similar to 1.
when the flag is set to false, both the scans should happen successfully.
 
3. On running a SCA scan on CLI Code, Initially there were 5 high level vulnerabilities and 3 medium level vulnerabilities. The rest of the vulnerabilities have been taken care of by updating the dependencies to the recommended versions. But,
 
There still exists one medium level vulnerability, for a direct dependency : [org.bouncycastle:bcprov-jdk15on @ 1.70](https://sca.checkmarx.net/#/projects/e331a09f-1e0f-48c7-871d-13f104d00b87/reports/886ebe20-d7dd-4b7a-bf97-ba5f31e6a77d/packages/Maven-org.bouncycastle%3Abcprov-jdk15on-1.70/packageDetailsGql) ,
which is because the latest version of the dependency itself has vulnerabilities.
CxSCA
 
4.  [[PLUG-1395] [CLI] Salesforce | 00180205 | In 9.6 ScanWithSettings V5 is not accepting a zip file if it's a GIT, SVN, TFS or a Perforce project - Jira (atlassian.net)](https://checkmarx.atlassian.net/jira/software/c/projects/PLUG/issues/PLUG-1395?jql=project%20%3D%20%22PLUG%22%20AND%20text%20~%20%22cli%22%20ORDER%20BY%20created%20DESC) . should be able to perform scan with 9.6 server without hotfix.


### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used


[PLUG-1395]: https://checkmarx.atlassian.net/browse/PLUG-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ