### PR TITLE
Jenkins Plugin Release Plugin Version 2024.1.2

### DIFF
--- a/src/main/java/com/cx/restclient/CxSASTClient.java
+++ b/src/main/java/com/cx/restclient/CxSASTClient.java
@@ -802,7 +802,8 @@ public class CxSASTClient extends LegacyClient implements Scanner {
             HashMap swaggerResponse = this.httpClient.getRequest(SWAGGER_LOCATION, CONTENT_TYPE_APPLICATION_JSON, HashMap.class, 200, SAST_SCAN, false);
             return swaggerResponse.toString().contains("/sast/scanWithSettings");
         } catch (Exception e) {
-            return false;
+        	// Assuming something went wrong but SAST version is greater than 9.x
+            return true;
         }
     }
 

--- a/src/main/java/com/cx/restclient/ast/AstScaClient.java
+++ b/src/main/java/com/cx/restclient/ast/AstScaClient.java
@@ -921,7 +921,7 @@ public class AstScaClient extends AstClient implements Scanner {
             log.info("Created a project with ID {}", resolvedProjectId);
         } else {
             log.info("Project already exists with ID {}", resolvedProjectId);
-            UpdateRiskManagementProject(resolvedProjectId,projectCustomTag);
+            UpdateRiskManagementProject(resolvedProjectId,projectCustomTag,assignedTeam);
         }
         return resolvedProjectId;
     }
@@ -1040,12 +1040,16 @@ public class AstScaClient extends AstClient implements Scanner {
         return newProject.getId();
     }
 
-   private void UpdateRiskManagementProject(String projectId, String customTags) throws IOException {
+   private void UpdateRiskManagementProject(String projectId, String customTags, String assignedTeam) throws IOException {
        Project existingProject = httpClient.getRequest(PROJECTID.replace("id",projectId),ContentType.CONTENT_TYPE_APPLICATION_JSON,Project.class,
                HttpStatus.SC_OK,"got project details",false);
 
      UpdateProjectRequest request = new UpdateProjectRequest();
      request.setName(existingProject.getName());
+		if (!StringUtils.isEmpty(assignedTeam)) {
+			request.addAssignedTeams(assignedTeam);
+			log.info("Team name: {}", assignedTeam);
+		}
 
      log.info("Project level custom tag name: {}",customTags);
        if(existingProject.getTags()!=null){

--- a/src/main/java/com/cx/restclient/ast/AstScaClient.java
+++ b/src/main/java/com/cx/restclient/ast/AstScaClient.java
@@ -308,8 +308,8 @@ public class AstScaClient extends AstClient implements Scanner {
 				}
 
 				fileName = PDF_REPORT_NAME + "_" + now + "." + reportFormat.toLowerCase();
-				String pdfLink = SASTUtils.writePDFReport(scanReport, config.getReportsDir(), fileName, log);
 				if (reportFormat.toLowerCase().equals("pdf")) {
+				String pdfLink = SASTUtils.writePDFReport(scanReport, config.getReportsDir(), fileName, log);
 					scaResults.setScaPDFLink(pdfLink);
 					scaResults.setPdfFileName(fileName);
 				}

--- a/src/main/java/com/cx/restclient/sast/utils/LegacyClient.java
+++ b/src/main/java/com/cx/restclient/sast/utils/LegacyClient.java
@@ -126,6 +126,9 @@ public abstract class LegacyClient {
 			}
         } else {
             projectId = projects.get(0).getId();
+            if(config.isEnableDataRetention()) {
+                setRetentionRate(projectId);
+            }
             setIsNewProject(false);
             log.info("Project already exists with ID {}", projectId);
         }


### PR DESCRIPTION


[PLUG-1815](https://checkmarx.atlassian.net/browse/PLUG-1815) : retention rate is not assignable to EXISTING SAST project

[PLUG-1817](https://checkmarx.atlassian.net/browse/PLUG-1817) : Downloading SCA report always shows 'PDF Report location' in logs when download format can be anything like Json,XML,PDF etc.


### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used


[PLUG-1815]: https://checkmarx.atlassian.net/browse/PLUG-1815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLUG-1817]: https://checkmarx.atlassian.net/browse/PLUG-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ