### PR TITLE
Jenkins Q2 Release

### DIFF
--- a/src/main/java/com/cx/restclient/CxSASTClient.java
+++ b/src/main/java/com/cx/restclient/CxSASTClient.java
@@ -541,7 +541,7 @@ public class CxSASTClient extends LegacyClient implements Scanner {
                 if (config.getReportsDir() != null) {
                     String now = new SimpleDateFormat("dd_MM_yyyy-HH_mm_ss").format(new Date());
                     String pdfFileName = PDF_REPORT_NAME + "_" + now + ".pdf";
-                    String pdfLink = writePDFReport(pdfReport, config.getReportsDir(), pdfFileName, log);
+                    String pdfLink = writePDFReport(pdfReport, config.getReportsDir(), pdfFileName, log, "PDF");
                     sastResults.setSastPDFLink(pdfLink);
                     sastResults.setPdfFileName(pdfFileName);
                 }

--- a/src/main/java/com/cx/restclient/ast/AstScaClient.java
+++ b/src/main/java/com/cx/restclient/ast/AstScaClient.java
@@ -308,8 +308,8 @@ public class AstScaClient extends AstClient implements Scanner {
 				}
 
 				fileName = PDF_REPORT_NAME + "_" + now + "." + reportFormat.toLowerCase();
+				String pdfLink = SASTUtils.writePDFReport(scanReport, config.getReportsDir(), fileName, log, reportFormat);
 				if (reportFormat.toLowerCase().equals("pdf")) {
-				String pdfLink = SASTUtils.writePDFReport(scanReport, config.getReportsDir(), fileName, log);
 					scaResults.setScaPDFLink(pdfLink);
 					scaResults.setPdfFileName(fileName);
 				}

--- a/src/main/java/com/cx/restclient/sast/utils/SASTUtils.java
+++ b/src/main/java/com/cx/restclient/sast/utils/SASTUtils.java
@@ -57,6 +57,7 @@ public abstract class SASTUtils {
     }
 
     //PDF Report
+    //This method is used for generate report for other file formats(CSV , XML, JSON etc) as well not only PDF file format.
     public static String writePDFReport(byte[] scanReport, File workspace, String pdfFileName, Logger log, String reportFormat) {
         try {
             FileUtils.writeByteArrayToFile(new File(workspace + CX_REPORT_LOCATION, pdfFileName), scanReport);

--- a/src/main/java/com/cx/restclient/sast/utils/SASTUtils.java
+++ b/src/main/java/com/cx/restclient/sast/utils/SASTUtils.java
@@ -57,12 +57,12 @@ public abstract class SASTUtils {
     }
 
     //PDF Report
-    public static String writePDFReport(byte[] scanReport, File workspace, String pdfFileName, Logger log) {
+    public static String writePDFReport(byte[] scanReport, File workspace, String pdfFileName, Logger log, String reportFormat) {
         try {
             FileUtils.writeByteArrayToFile(new File(workspace + CX_REPORT_LOCATION, pdfFileName), scanReport);
-            log.info("PDF report location: " + workspace + CX_REPORT_LOCATION + File.separator + pdfFileName);
+            log.info("" +reportFormat + " Report Location: " + workspace + CX_REPORT_LOCATION+ File.separator+ pdfFileName);
         } catch (Exception e) {
-            log.error("Failed to write PDF report to workspace: ", e.getMessage());
+        	log.error("Failed to write "+reportFormat+" report to workspace: ", e.getMessage());
             pdfFileName = "";
         }
         return pdfFileName;


### PR DESCRIPTION

[https://checkmarx.atlassian.net/browse/PLUG-1817](Downloading SCA report always shows 'PDF Report location' in logs when download format can be anything like Json,XML,PDF etc.) 
Test cases covered:

1) SAST + SCA with PDF report enabled 
2) SAST + SCA with sast PDF enable and sca PDF disabled
3) SAST + SCA with sast PDF disabled and sca PDF enabled
4) SAST + SCA both report disabled
5) SAST + SCA with sast PDF enable and sca XML enabled
6) SAST + SCA with sast PDF enable and sca CSV enabled
7) SAST + SCA with sast PDF enable and sca JSON enabled
8) SAST + SCA with sast PDF enable and sca cyclonedxJSON enabled
9) SAST + SCA with sast PDF enable and sca cyclonedxXML enabled

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
