### PR TITLE
Vulnerability Fix: Commons-collections:3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,19 +164,8 @@
                     <artifactId>commons-collections</artifactId>
                     <groupId>commons-collections</groupId>
                 </exclusion>
-                <exclusion>
-                    <artifactId>commons-validator</artifactId>
-                    <groupId>commons-validator</groupId>
-                </exclusion>
             </exclusions>
-        </dependency>
-        <!-- excluded dependencies from fsa -->
-        <dependency>
-            <groupId>commons-validator</groupId>
-            <artifactId>commons-validator</artifactId>
-            <version>1.8.0</version>
-        </dependency>
-        <!-- end of excluded dependencies -->        
+        </dependency>        
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>


### PR DESCRIPTION
### Description

> Vulnerability Fix: Commons-collections:3.2.2, removed exclusion and dependency: commons-validator

### Testing

> Since the dependency was not directly getting used anywhere, build was successful without the dependency as well.
>Tested with the plugins: Jenkins and CLI

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
