### PR TITLE
  Add hostname verification support for HTTPS connections

### DIFF
--- a/src/main/java/com/cx/restclient/ast/AstClient.java
+++ b/src/main/java/com/cx/restclient/ast/AstClient.java
@@ -86,7 +86,8 @@ public abstract class AstClient {
                 log,
                 config.getNTLM(),
                 config.getPluginVersion(),
-                config.getAllowedHostname());
+                config.getAllowedHostname(),
+                config.getHostnameVerificationEnabled());
         //initializing Team Path to prevent null pointer in login when called from automation
         client.setTeamPathHeader("");
 

--- a/src/main/java/com/cx/restclient/ast/AstClient.java
+++ b/src/main/java/com/cx/restclient/ast/AstClient.java
@@ -85,7 +85,8 @@ public abstract class AstClient {
                 config.getScaProxyConfig(),
                 log,
                 config.getNTLM(),
-                config.getPluginVersion());
+                config.getPluginVersion(),
+                config.getAllowedHostname());
         //initializing Team Path to prevent null pointer in login when called from automation
         client.setTeamPathHeader("");
 

--- a/src/main/java/com/cx/restclient/ast/ClientTypeResolver.java
+++ b/src/main/java/com/cx/restclient/ast/ClientTypeResolver.java
@@ -99,7 +99,8 @@ public class ClientTypeResolver {
                     log,
                     config.getNTLM(),
                     config.getPluginVersion(),
-                    config.getAllowedHostname());
+                    config.getAllowedHostname(),
+                    config.getHostnameVerificationEnabled());
         }
         return httpClient;
     }

--- a/src/main/java/com/cx/restclient/ast/ClientTypeResolver.java
+++ b/src/main/java/com/cx/restclient/ast/ClientTypeResolver.java
@@ -98,7 +98,8 @@ public class ClientTypeResolver {
                     config.getScaProxyConfig(),
                     log,
                     config.getNTLM(),
-                    config.getPluginVersion());
+                    config.getPluginVersion(),
+                    config.getAllowedHostname());
         }
         return httpClient;
     }

--- a/src/main/java/com/cx/restclient/configuration/CxScanConfig.java
+++ b/src/main/java/com/cx/restclient/configuration/CxScanConfig.java
@@ -34,6 +34,7 @@ public class CxScanConfig implements Serializable {
     private boolean enableDataRetention;
     private boolean disableCertificateValidation = false;
     private String allowedHostname;
+    private Boolean hostnameVerificationEnabled;
     private boolean useSSOLogin = false;
 
     private String sourceDir;
@@ -266,6 +267,14 @@ public class CxScanConfig implements Serializable {
 
     public void setAllowedHostname(String allowedHostname) {
         this.allowedHostname = allowedHostname;
+    }
+
+    public Boolean getHostnameVerificationEnabled() {
+        return hostnameVerificationEnabled;
+    }
+
+    public void setHostnameVerificationEnabled(Boolean hostnameVerificationEnabled) {
+        this.hostnameVerificationEnabled = hostnameVerificationEnabled;
     }
 
     public boolean isUseSSOLogin() {

--- a/src/main/java/com/cx/restclient/configuration/CxScanConfig.java
+++ b/src/main/java/com/cx/restclient/configuration/CxScanConfig.java
@@ -33,6 +33,7 @@ public class CxScanConfig implements Serializable {
 	private Integer projectRetentionRate;
     private boolean enableDataRetention;
     private boolean disableCertificateValidation = false;
+    private String allowedHostname;
     private boolean useSSOLogin = false;
 
     private String sourceDir;
@@ -257,6 +258,14 @@ public class CxScanConfig implements Serializable {
 
     public void setDisableCertificateValidation(boolean disableCertificateValidation) {
         this.disableCertificateValidation = disableCertificateValidation;
+    }
+
+    public String getAllowedHostname() {
+        return allowedHostname;
+    }
+
+    public void setAllowedHostname(String allowedHostname) {
+        this.allowedHostname = allowedHostname;
     }
 
     public boolean isUseSSOLogin() {

--- a/src/main/java/com/cx/restclient/httpClient/CxHostnameVerifier.java
+++ b/src/main/java/com/cx/restclient/httpClient/CxHostnameVerifier.java
@@ -193,8 +193,7 @@ public class CxHostnameVerifier implements HostnameVerifier {
     }
 
     private static boolean isIpAddress(String hostname) {
-        // Simple check: an IP address contains only digits and dots (IPv4)
-        // or contains a colon (IPv6)
-        return hostname.matches("\\d+\\.\\d+\\.\\d+\\.\\d+") || hostname.contains(":");
+        return hostname.matches("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}")
+                || hostname.matches(".*:.*:.*");
     }
 }

--- a/src/main/java/com/cx/restclient/httpClient/CxHostnameVerifier.java
+++ b/src/main/java/com/cx/restclient/httpClient/CxHostnameVerifier.java
@@ -1,0 +1,200 @@
+package com.cx.restclient.httpClient;
+
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Custom HostnameVerifier with multi-level fallback:
+ * 1. Delegates to Apache's DefaultHostnameVerifier (RFC 2818: CN, SAN, wildcard matching)
+ * 2. Falls back to allowedHostname from config property (CLI only, null for other plugins)
+ * 3. Falls back to CX_ALLOWED_HOSTS environment variable (comma-separated patterns, all plugins)
+ * 4. If all fail, returns false (connection rejected)
+ */
+public class CxHostnameVerifier implements HostnameVerifier {
+
+    private static final Logger log = LoggerFactory.getLogger(CxHostnameVerifier.class);
+    private static final String ENV_ALLOWED_HOSTS = "CX_ALLOWED_HOSTS";
+
+    private final DefaultHostnameVerifier defaultVerifier = new DefaultHostnameVerifier();
+    private final String allowedHostname;
+    private final String envAllowedHostname;
+
+    public CxHostnameVerifier(String allowedHostname) {
+        this.allowedHostname = allowedHostname;
+        this.envAllowedHostname = System.getenv(ENV_ALLOWED_HOSTS);
+        log.info("[HostnameVerifier] Initialized. Config ssl.allowed.hosts='{}', Env CX_ALLOWED_HOSTS='{}'",
+                allowedHostname != null ? allowedHostname : "<not set>",
+                envAllowedHostname != null ? envAllowedHostname : "<not set>");
+    }
+
+    @Override
+    public boolean verify(String hostname, SSLSession session) {
+        log.info("[HostnameVerifier] ===== Starting hostname verification for '{}' =====", hostname);
+
+        // Log certificate details for debugging
+        logCertificateDetails(session);
+
+        // Step 1: Try standard CN/SAN verification (RFC 2818)
+        log.info("[HostnameVerifier] Step 1: Checking CN/SAN in certificate against hostname '{}'...", hostname);
+        if (defaultVerifier.verify(hostname, session)) {
+            log.info("[HostnameVerifier] Step 1 PASSED: Hostname '{}' matched CN/SAN in certificate. Connection allowed.", hostname);
+            return true;
+        }
+        log.warn("[HostnameVerifier] Step 1 FAILED: Hostname '{}' did NOT match any CN or SAN entry in certificate.", hostname);
+
+        // Step 2: Check allowedHostname from config property (ssl.allowed.hosts)
+        log.info("[HostnameVerifier] Step 2: Checking config property 'ssl.allowed.hosts'...");
+        if (allowedHostname != null && !allowedHostname.trim().isEmpty()) {
+            String[] patterns = allowedHostname.split(",");
+            log.info("[HostnameVerifier] Step 2: Config property has {} pattern(s): '{}'", patterns.length, allowedHostname);
+            for (String pattern : patterns) {
+                String trimmed = pattern.trim();
+                log.info("[HostnameVerifier] Step 2: Comparing hostname '{}' against config pattern '{}'...", hostname, trimmed);
+                if (matchesPattern(hostname, trimmed)) {
+                    log.info("[HostnameVerifier] Step 2 PASSED: Hostname '{}' matched allowed hostname pattern '{}' from config property. Connection allowed.", hostname, trimmed);
+                    return true;
+                }
+                log.info("[HostnameVerifier] Step 2: No match for pattern '{}'.", trimmed);
+            }
+            log.warn("[HostnameVerifier] Step 2 FAILED: Hostname '{}' did not match any config pattern.", hostname);
+        } else {
+            log.info("[HostnameVerifier] Step 2 SKIPPED: Config property 'ssl.allowed.hosts' is not set or empty.");
+        }
+
+        // Step 3: Check CX_ALLOWED_HOSTS environment variable (read once at construction)
+        log.info("[HostnameVerifier] Step 3: Checking environment variable 'CX_ALLOWED_HOSTS'...");
+        if (envAllowedHostname != null && !envAllowedHostname.trim().isEmpty()) {
+            String[] patterns = envAllowedHostname.split(",");
+            log.info("[HostnameVerifier] Step 3: Env variable has {} pattern(s): '{}'", patterns.length, envAllowedHostname);
+            for (String pattern : patterns) {
+                String trimmed = pattern.trim();
+                log.info("[HostnameVerifier] Step 3: Comparing hostname '{}' against env pattern '{}'...", hostname, trimmed);
+                if (matchesPattern(hostname, trimmed)) {
+                    log.info("[HostnameVerifier] Step 3 PASSED: Hostname '{}' matched allowed hostname pattern '{}' from environment variable. Connection allowed.", hostname, trimmed);
+                    return true;
+                }
+                log.info("[HostnameVerifier] Step 3: No match for pattern '{}'.", trimmed);
+            }
+            log.warn("[HostnameVerifier] Step 3 FAILED: Hostname '{}' did not match any env variable pattern.", hostname);
+        } else {
+            log.info("[HostnameVerifier] Step 3 SKIPPED: Environment variable 'CX_ALLOWED_HOSTS' is not set or empty.");
+        }
+
+        // Step 4: All checks failed
+        log.error("[HostnameVerifier] Step 4: ALL CHECKS FAILED for hostname '{}'. Connection REJECTED.", hostname);
+        log.error("[HostnameVerifier] To resolve: set 'ssl.allowed.hosts={}' in cx_console.properties OR set environment variable CX_ALLOWED_HOSTS={}", hostname, hostname);
+        return false;
+    }
+
+    /**
+     * Logs the certificate CN and SAN details from the SSL session.
+     */
+    private void logCertificateDetails(SSLSession session) {
+        try {
+            Certificate[] certs = session.getPeerCertificates();
+            if (certs == null || certs.length == 0) {
+                log.warn("[HostnameVerifier] No peer certificates found in SSL session.");
+                return;
+            }
+            X509Certificate x509 = (X509Certificate) certs[0];
+
+            // Log CN
+            String subjectDN = x509.getSubjectX500Principal().getName();
+            log.info("[HostnameVerifier] Certificate Subject DN: {}", subjectDN);
+
+            // Extract and log CN
+            String cn = extractCN(subjectDN);
+            log.info("[HostnameVerifier] Certificate CN (Common Name): {}", cn != null ? cn : "<not present>");
+
+            // Log SAN
+            Collection<List<?>> sans = x509.getSubjectAlternativeNames();
+            if (sans != null && !sans.isEmpty()) {
+                StringBuilder sanList = new StringBuilder();
+                for (List<?> san : sans) {
+                    Integer type = (Integer) san.get(0);
+                    Object value = san.get(1);
+                    String typeLabel;
+                    switch (type) {
+                        case 2: typeLabel = "DNS"; break;
+                        case 7: typeLabel = "IP"; break;
+                        default: typeLabel = "Type-" + type; break;
+                    }
+                    if (sanList.length() > 0) sanList.append(", ");
+                    sanList.append(typeLabel).append(":").append(value);
+                }
+                log.info("[HostnameVerifier] Certificate SAN (Subject Alternative Names): [{}]", sanList.toString());
+            } else {
+                log.info("[HostnameVerifier] Certificate SAN (Subject Alternative Names): <not present>");
+            }
+
+            // Log validity
+            log.info("[HostnameVerifier] Certificate valid from {} to {}", x509.getNotBefore(), x509.getNotAfter());
+            log.info("[HostnameVerifier] Certificate issuer: {}", x509.getIssuerX500Principal().getName());
+
+        } catch (Exception e) {
+            log.warn("[HostnameVerifier] Could not extract certificate details: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Extracts CN from a subject DN string like "CN=*.cxquality.com, OU=..., O=..."
+     */
+    private String extractCN(String subjectDN) {
+        if (subjectDN == null) return null;
+        for (String part : subjectDN.split(",")) {
+            String trimmed = part.trim();
+            if (trimmed.toUpperCase().startsWith("CN=")) {
+                return trimmed.substring(3);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Supports exact match and wildcard patterns like *.domain.com.
+     */
+    static boolean matchesPattern(String hostname, String pattern) {
+        if (hostname == null || pattern == null || hostname.isEmpty() || pattern.isEmpty()) {
+            return false;
+        }
+
+        // Exact match (case-insensitive)
+        if (hostname.equalsIgnoreCase(pattern)) {
+            log.info("[HostnameVerifier]   -> Exact match: '{}' equals '{}' (case-insensitive)", hostname, pattern);
+            return true;
+        }
+
+        // Wildcard match: *.domain.com should match sub.domain.com
+        // but not domain.com or a.b.domain.com (RFC 6125 Section 6.4.3)
+        // Wildcards do not apply to IP addresses.
+        if (pattern.startsWith("*.") && !isIpAddress(hostname)) {
+            String suffix = pattern.substring(1).toLowerCase(); // e.g., ".domain.com"
+            String lower = hostname.toLowerCase();
+            boolean endsWith = lower.endsWith(suffix);
+            boolean singleLevel = !lower.substring(0, Math.max(0, lower.length() - suffix.length())).contains(".");
+            log.info("[HostnameVerifier]   -> Wildcard check: hostname='{}', pattern='{}', endsWith('{}')={}, singleLevelSubdomain={}",
+                    hostname, pattern, suffix, endsWith, singleLevel);
+            return endsWith && singleLevel;
+        }
+
+        if (pattern.startsWith("*.") && isIpAddress(hostname)) {
+            log.info("[HostnameVerifier]   -> Wildcard pattern '{}' skipped: hostname '{}' is an IP address (wildcards not applicable to IPs per RFC 6125)", pattern, hostname);
+        }
+
+        return false;
+    }
+
+    private static boolean isIpAddress(String hostname) {
+        // Simple check: an IP address contains only digits and dots (IPv4)
+        // or contains a colon (IPv6)
+        return hostname.matches("\\d+\\.\\d+\\.\\d+\\.\\d+") || hostname.contains(":");
+    }
+}

--- a/src/main/java/com/cx/restclient/httpClient/CxHttpClient.java
+++ b/src/main/java/com/cx/restclient/httpClient/CxHttpClient.java
@@ -39,6 +39,7 @@ import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustAllStrategy;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import javax.net.ssl.HostnameVerifier;
 import org.apache.http.cookie.Cookie;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
@@ -131,7 +132,13 @@ public class CxHttpClient implements Closeable {
 
     public CxHttpClient(String rootUri, String origin, boolean disableSSLValidation, boolean isSSO, String refreshToken,
                         boolean isProxy, @Nullable ProxyConfig proxyConfig, Logger log, Boolean useNTLM, String pluginVersion) throws CxClientException {
-    	   	   	
+        this(rootUri, origin, disableSSLValidation, isSSO, refreshToken, isProxy, proxyConfig, log, useNTLM, pluginVersion, null);
+    }
+
+    public CxHttpClient(String rootUri, String origin, boolean disableSSLValidation, boolean isSSO, String refreshToken,
+                        boolean isProxy, @Nullable ProxyConfig proxyConfig, Logger log, Boolean useNTLM, String pluginVersion,
+                        String allowedHostname) throws CxClientException {
+
         this.log = log;
         this.rootUri = rootUri;
         this.refreshToken = refreshToken;
@@ -147,6 +154,9 @@ public class CxHttpClient implements Closeable {
         Registry<ConnectionSocketFactory> registry;
         PoolingHttpClientConnectionManager cm = null;
         if (disableSSLValidation) {
+            log.info("[SSL Config] SSL validation is DISABLED (-trusted_certificates flag is set).");
+            log.info("[SSL Config] Using NoopHostnameVerifier - ALL hostname verification is SKIPPED.");
+            log.info("[SSL Config] Using TrustSelfSignedStrategy - self-signed certificates will be accepted.");
             try {
                 builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
                 sslConnectionSocketFactory = new SSLConnectionSocketFactory(builder.build(), NoopHostnameVerifier.INSTANCE);
@@ -162,10 +172,16 @@ public class CxHttpClient implements Closeable {
             cb.setSSLSocketFactory(sslConnectionSocketFactory);
             cb.setConnectionManager(cm);
         } else {
+            log.info("[SSL Config] SSL validation is ENABLED. Hostname verification will be performed.");
         	String customTrustStore = System.getProperty("javax.net.ssl.trustStore");
-        	if(!StringUtils.isEmpty(customTrustStore))
-        		this.log.info("Custom truststore is configured. Ensure that trusted certificate for all CxSAST/CxSCA endpoints are imported. Custom store path: " + customTrustStore );
-            cb.setConnectionManager(getHttpConnectionManager(false));
+        	if(!StringUtils.isEmpty(customTrustStore)) {
+        		this.log.info("[SSL Config] Custom truststore is configured. Path: " + customTrustStore);
+        		this.log.info("[SSL Config] Ensure that trusted certificate/chain for all CxSAST/CxSCA endpoints are imported in this truststore.");
+        	} else {
+        	    this.log.info("[SSL Config] Using default JVM truststore (cacerts). No custom truststore configured.");
+        	}
+            log.info("[SSL Config] Using CxHostnameVerifier with 4-step fallback chain.");
+            cb.setConnectionManager(getHttpConnectionManager(false, new CxHostnameVerifier(allowedHostname)));
         }
         cb.setConnectionManagerShared(true);
 
@@ -190,7 +206,14 @@ public class CxHttpClient implements Closeable {
 
     public CxHttpClient(String rootUri, String origin, String originUrl, boolean disableSSLValidation, boolean isSSO, String refreshToken,
                         boolean isProxy, @Nullable ProxyConfig proxyConfig, Logger log, Boolean useNTLM, String pluginVersion) throws CxClientException {
-        this(rootUri, origin, disableSSLValidation, isSSO, refreshToken, isProxy, proxyConfig, log, useNTLM, pluginVersion);
+        this(rootUri, origin, disableSSLValidation, isSSO, refreshToken, isProxy, proxyConfig, log, useNTLM, pluginVersion, (String) null);
+        this.cxOriginUrl = originUrl;
+    }
+
+    public CxHttpClient(String rootUri, String origin, String originUrl, boolean disableSSLValidation, boolean isSSO, String refreshToken,
+                        boolean isProxy, @Nullable ProxyConfig proxyConfig, Logger log, Boolean useNTLM, String pluginVersion,
+                        String allowedHostname) throws CxClientException {
+        this(rootUri, origin, disableSSLValidation, isSSO, refreshToken, isProxy, proxyConfig, log, useNTLM, pluginVersion, allowedHostname);
         this.cxOriginUrl = originUrl;
     }
 
@@ -345,12 +368,12 @@ public class CxHttpClient implements Closeable {
         return new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
     }
 
-    private static PoolingHttpClientConnectionManager getHttpConnectionManager(boolean disableSSLValidation) {
+    private static PoolingHttpClientConnectionManager getHttpConnectionManager(boolean disableSSLValidation, HostnameVerifier hostnameVerifier) {
         ConnectionSocketFactory factory;
         if (disableSSLValidation) {
             factory = getTrustAllSSLSocketFactory();
         } else {
-            factory = new SSLConnectionSocketFactory(SSLContexts.createDefault(), NoopHostnameVerifier.INSTANCE);
+            factory = new SSLConnectionSocketFactory(SSLContexts.createDefault(), hostnameVerifier);
         }
         Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory>create()
                 .register(HTTPS, factory)

--- a/src/main/java/com/cx/restclient/httpClient/CxHttpClient.java
+++ b/src/main/java/com/cx/restclient/httpClient/CxHttpClient.java
@@ -97,6 +97,7 @@ public class CxHttpClient implements Closeable {
     private static String HTTPS_NO_HOST = System.getProperty("https.nonProxyHosts");
 
     private static final String HTTPS = "https";
+    private static final String ENV_HOSTNAME_VERIFICATION = "CX_HOSTNAME_VERIFICATION_ENABLED";
 
     private static final String LOGIN_FAILED_MSG = "Fail to login with windows authentication: ";
 
@@ -130,14 +131,27 @@ public class CxHttpClient implements Closeable {
     private String pluginVersion;
 
 
+    /**
+     * Legacy 10-arg constructor — kept for binary compatibility with existing plugin builds
+     * Delegates to the canonical 12-arg constructor with null values for the new parameters,
+     * which causes the resolver to fall back to the CX_HOSTNAME_VERIFICATION_ENABLED env var
+     * (defaulting to false / legacy NoopHostnameVerifier behavior).
+     */
     public CxHttpClient(String rootUri, String origin, boolean disableSSLValidation, boolean isSSO, String refreshToken,
                         boolean isProxy, @Nullable ProxyConfig proxyConfig, Logger log, Boolean useNTLM, String pluginVersion) throws CxClientException {
-        this(rootUri, origin, disableSSLValidation, isSSO, refreshToken, isProxy, proxyConfig, log, useNTLM, pluginVersion, null);
+        this(rootUri, origin, disableSSLValidation, isSSO, refreshToken, isProxy, proxyConfig, log, useNTLM, pluginVersion, null, null);
     }
 
+    /**
+     * Canonical 12-arg constructor. Used by CLI (which reads ssl.hostname.verification.enabled
+     * and ssl.allowed.hosts from cx_console.properties) and any plugin that opts in.
+     *
+     * @param allowedHostname              Comma-separated list of allowed host patterns; null for plugins that don't support it.
+     * @param hostnameVerificationEnabled  Tri-state flag: true = on, false = off, null = fall back to env var then default false.
+     */
     public CxHttpClient(String rootUri, String origin, boolean disableSSLValidation, boolean isSSO, String refreshToken,
                         boolean isProxy, @Nullable ProxyConfig proxyConfig, Logger log, Boolean useNTLM, String pluginVersion,
-                        String allowedHostname) throws CxClientException {
+                        String allowedHostname, Boolean hostnameVerificationEnabled) throws CxClientException {
 
         this.log = log;
         this.rootUri = rootUri;
@@ -172,16 +186,30 @@ public class CxHttpClient implements Closeable {
             cb.setSSLSocketFactory(sslConnectionSocketFactory);
             cb.setConnectionManager(cm);
         } else {
-            log.info("[SSL Config] SSL validation is ENABLED. Hostname verification will be performed.");
-        	String customTrustStore = System.getProperty("javax.net.ssl.trustStore");
-        	if(!StringUtils.isEmpty(customTrustStore)) {
-        		this.log.info("[SSL Config] Custom truststore is configured. Path: " + customTrustStore);
-        		this.log.info("[SSL Config] Ensure that trusted certificate/chain for all CxSAST/CxSCA endpoints are imported in this truststore.");
-        	} else {
-        	    this.log.info("[SSL Config] Using default JVM truststore (cacerts). No custom truststore configured.");
-        	}
-            log.info("[SSL Config] Using CxHostnameVerifier with 4-step fallback chain.");
-            cb.setConnectionManager(getHttpConnectionManager(false, new CxHostnameVerifier(allowedHostname)));
+            log.info("[SSL Config] SSL validation is ENABLED.");
+            String customTrustStore = System.getProperty("javax.net.ssl.trustStore");
+            if (!StringUtils.isEmpty(customTrustStore)) {
+                this.log.info("[SSL Config] Custom truststore is configured. Path: " + customTrustStore);
+                this.log.info("[SSL Config] Ensure that trusted certificate/chain for all CxSAST/CxSCA endpoints are imported in this truststore.");
+            } else {
+                this.log.info("[SSL Config] Using default JVM truststore (cacerts). No custom truststore configured.");
+            }
+
+            boolean verifyHostname = resolveHostnameVerificationFlag(hostnameVerificationEnabled, log);
+            if (verifyHostname) {
+                log.info("[SSL Config] Hostname verification ENABLED. Using CxHostnameVerifier with fallback chain (CN/SAN -> ssl.allowed.hosts -> CX_ALLOWED_HOSTS).");
+                if (allowedHostname != null && !allowedHostname.trim().isEmpty()) {
+                    log.info("[SSL Config] Allowed hosts list (from config): {}", allowedHostname);
+                }
+                cb.setConnectionManager(getHttpConnectionManager(false, new CxHostnameVerifier(allowedHostname)));
+            } else {
+                log.info("[SSL Config] Hostname verification DISABLED (legacy behavior). Using NoopHostnameVerifier.");
+                log.info("[SSL Config] To enable hostname verification, set CX_HOSTNAME_VERIFICATION_ENABLED=true (or ssl.hostname.verification.enabled=true in cx_console.properties for CLI).");
+                if (allowedHostname != null && !allowedHostname.trim().isEmpty()) {
+                    log.warn("[SSL Config] ssl.allowed.hosts is set but hostname verification is DISABLED. The allowed hosts list will have NO EFFECT until hostname verification is enabled.");
+                }
+                cb.setConnectionManager(getHttpConnectionManager(false, NoopHostnameVerifier.INSTANCE));
+            }
         }
         cb.setConnectionManagerShared(true);
 
@@ -204,16 +232,24 @@ public class CxHttpClient implements Closeable {
         } else apacheClient = cb.build();
     }
 
+    /**
+     * Legacy originUrl 11-arg constructor — backward compatibility for plugins that use the
+     * originUrl variant (e.g. older AstClient builds). Falls through to env var / default.
+     */
     public CxHttpClient(String rootUri, String origin, String originUrl, boolean disableSSLValidation, boolean isSSO, String refreshToken,
                         boolean isProxy, @Nullable ProxyConfig proxyConfig, Logger log, Boolean useNTLM, String pluginVersion) throws CxClientException {
-        this(rootUri, origin, disableSSLValidation, isSSO, refreshToken, isProxy, proxyConfig, log, useNTLM, pluginVersion, (String) null);
+        this(rootUri, origin, disableSSLValidation, isSSO, refreshToken, isProxy, proxyConfig, log, useNTLM, pluginVersion, null, null);
         this.cxOriginUrl = originUrl;
     }
 
+    /**
+     * Canonical 13-arg originUrl constructor. Used by AstClient (SCA / AST-SAST) to pass
+     * both allowedHostname and hostnameVerificationEnabled along with the originUrl.
+     */
     public CxHttpClient(String rootUri, String origin, String originUrl, boolean disableSSLValidation, boolean isSSO, String refreshToken,
                         boolean isProxy, @Nullable ProxyConfig proxyConfig, Logger log, Boolean useNTLM, String pluginVersion,
-                        String allowedHostname) throws CxClientException {
-        this(rootUri, origin, disableSSLValidation, isSSO, refreshToken, isProxy, proxyConfig, log, useNTLM, pluginVersion, allowedHostname);
+                        String allowedHostname, Boolean hostnameVerificationEnabled) throws CxClientException {
+        this(rootUri, origin, disableSSLValidation, isSSO, refreshToken, isProxy, proxyConfig, log, useNTLM, pluginVersion, allowedHostname, hostnameVerificationEnabled);
         this.cxOriginUrl = originUrl;
     }
 
@@ -366,6 +402,29 @@ public class CxHttpClient implements Closeable {
             throw new CxClientException("Fail to set trust all certificate, 'SSLConnectionSocketFactory'", e);
         }
         return new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
+    }
+
+    /**
+     * Resolves whether hostname verification should be enabled.
+     * Priority (highest to lowest):
+     *   1. Explicit value passed via constructor (e.g. CLI from cx_console.properties)
+     *   2. CX_HOSTNAME_VERIFICATION_ENABLED environment variable (works for all plugins)
+     *   3. Default: false (legacy NoopHostnameVerifier behavior - no impact on existing pipelines)
+     */
+    private static boolean resolveHostnameVerificationFlag(Boolean explicitValue, Logger log) {
+        if (explicitValue != null) {
+            log.info("[SSL Config] Hostname verification flag from config: {}", explicitValue);
+            return explicitValue;
+        }
+        String envValue = System.getenv(ENV_HOSTNAME_VERIFICATION);
+        if (envValue != null && !envValue.trim().isEmpty()) {
+            boolean parsed = Boolean.parseBoolean(envValue.trim());
+            log.info("[SSL Config] Hostname verification flag from env var {}={} (parsed as {})",
+                    ENV_HOSTNAME_VERIFICATION, envValue, parsed);
+            return parsed;
+        }
+        log.info("[SSL Config] Hostname verification flag not set (no config, no env var). Defaulting to FALSE (legacy behavior).");
+        return false;
     }
 
     private static PoolingHttpClientConnectionManager getHttpConnectionManager(boolean disableSSLValidation, HostnameVerifier hostnameVerifier) {

--- a/src/main/java/com/cx/restclient/sast/utils/LegacyClient.java
+++ b/src/main/java/com/cx/restclient/sast/utils/LegacyClient.java
@@ -267,7 +267,8 @@ public abstract class LegacyClient {
                     log,
                     config.getNTLM(),
                     config.getPluginVersion(),
-                    config.getAllowedHostname());
+                    config.getAllowedHostname(),
+                    config.getHostnameVerificationEnabled());
         }
     }
 

--- a/src/main/java/com/cx/restclient/sast/utils/LegacyClient.java
+++ b/src/main/java/com/cx/restclient/sast/utils/LegacyClient.java
@@ -255,7 +255,7 @@ public abstract class LegacyClient {
     private void initHttpClient(CxScanConfig config, Logger log) throws MalformedURLException {
     	if (!org.apache.commons.lang3.StringUtils.isEmpty(config.getUrl())) {
         	httpClient = new CxHttpClient(
-            		
+
                     UrlUtils.parseURLToString(config.getUrl(), "CxRestAPI/"),
                     config.getCxOrigin(),
                     config.getCxOriginUrl(),
@@ -266,7 +266,8 @@ public abstract class LegacyClient {
                     config.getProxyConfig(),
                     log,
                     config.getNTLM(),
-                    config.getPluginVersion());
+                    config.getPluginVersion(),
+                    config.getAllowedHostname());
         }
     }
 

--- a/src/test/java/com/cx/restclient/httpClient/CxHostnameVerifierTest.java
+++ b/src/test/java/com/cx/restclient/httpClient/CxHostnameVerifierTest.java
@@ -1,0 +1,146 @@
+package com.cx.restclient.httpClient;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CxHostnameVerifierTest {
+
+    // --- Exact match ---
+
+    @Test
+    public void exactMatch_sameCase() {
+        assertTrue(CxHostnameVerifier.matchesPattern("server.checkmarx.com", "server.checkmarx.com"));
+    }
+
+    @Test
+    public void exactMatch_caseInsensitive() {
+        assertTrue(CxHostnameVerifier.matchesPattern("Server.Checkmarx.COM", "server.checkmarx.com"));
+    }
+
+    @Test
+    public void exactMatch_noMatch() {
+        assertFalse(CxHostnameVerifier.matchesPattern("other.checkmarx.com", "server.checkmarx.com"));
+    }
+
+    // --- Wildcard match (single level per RFC 6125) ---
+
+    @Test
+    public void wildcard_matchesSingleSubdomain() {
+        assertTrue(CxHostnameVerifier.matchesPattern("sast.checkmarx.com", "*.checkmarx.com"));
+    }
+
+    @Test
+    public void wildcard_caseInsensitive() {
+        assertTrue(CxHostnameVerifier.matchesPattern("SAST.Checkmarx.COM", "*.checkmarx.com"));
+    }
+
+    @Test
+    public void wildcard_doesNotMatchBareDomain() {
+        // *.checkmarx.com should NOT match checkmarx.com itself
+        assertFalse(CxHostnameVerifier.matchesPattern("checkmarx.com", "*.checkmarx.com"));
+    }
+
+    @Test
+    public void wildcard_doesNotMatchMultiLevelSubdomain() {
+        // RFC 6125: *.domain.com must not match a.b.domain.com
+        assertFalse(CxHostnameVerifier.matchesPattern("a.b.checkmarx.com", "*.checkmarx.com"));
+    }
+
+    @Test
+    public void wildcard_doesNotMatchDeeplyNested() {
+        assertFalse(CxHostnameVerifier.matchesPattern("x.y.z.checkmarx.com", "*.checkmarx.com"));
+    }
+
+    @Test
+    public void wildcard_doesNotMatchUnrelatedDomain() {
+        assertFalse(CxHostnameVerifier.matchesPattern("sast.otherdomain.com", "*.checkmarx.com"));
+    }
+
+    // --- IP address exact match ---
+
+    @Test
+    public void ipAddress_exactMatch() {
+        assertTrue(CxHostnameVerifier.matchesPattern("192.168.1.100", "192.168.1.100"));
+    }
+
+    @Test
+    public void ipAddress_noMatch() {
+        assertFalse(CxHostnameVerifier.matchesPattern("192.168.1.101", "192.168.1.100"));
+    }
+
+    @Test
+    public void ipAddress_wildcardDoesNotApply() {
+        // Wildcard patterns should not work for IP addresses
+        assertFalse(CxHostnameVerifier.matchesPattern("192.168.1.100", "*.168.1.100"));
+    }
+
+    // --- Null and empty inputs ---
+
+    @Test
+    public void nullHostname_returnsFalse() {
+        assertFalse(CxHostnameVerifier.matchesPattern(null, "*.checkmarx.com"));
+    }
+
+    @Test
+    public void nullPattern_returnsFalse() {
+        assertFalse(CxHostnameVerifier.matchesPattern("sast.checkmarx.com", null));
+    }
+
+    @Test
+    public void bothNull_returnsFalse() {
+        assertFalse(CxHostnameVerifier.matchesPattern(null, null));
+    }
+
+    @Test
+    public void emptyHostname_returnsFalse() {
+        assertFalse(CxHostnameVerifier.matchesPattern("", "*.checkmarx.com"));
+    }
+
+    @Test
+    public void emptyPattern_returnsFalse() {
+        assertFalse(CxHostnameVerifier.matchesPattern("sast.checkmarx.com", ""));
+    }
+
+    // --- Edge cases ---
+
+    @Test
+    public void wildcardOnly_doesNotMatchAnything() {
+        // Pattern "*" (without dot) doesn't start with "*." so no wildcard match
+        assertFalse(CxHostnameVerifier.matchesPattern("anything.com", "*"));
+    }
+
+    @Test
+    public void wildcardDotOnly_doesNotMatchSingleLabel() {
+        // "*." should not match a hostname with no further labels
+        assertFalse(CxHostnameVerifier.matchesPattern("com", "*."));
+    }
+
+    @Test
+    public void singleLabelHostname_noWildcardMatch() {
+        assertFalse(CxHostnameVerifier.matchesPattern("localhost", "*.localhost"));
+    }
+
+    // --- verify() integration with config-based fallback ---
+
+    @Test
+    public void verify_configPatternMatches() {
+        CxHostnameVerifier verifier = new CxHostnameVerifier("sast.checkmarx.com,*.internal.com");
+        // DefaultHostnameVerifier will fail (no real SSL session), so it falls through to config
+        // We can't easily mock SSLSession, but we can test that matchesPattern logic is correct
+        // through the static method tests above. This test validates construction doesn't throw.
+        assertNotNull(verifier);
+    }
+
+    @Test
+    public void verify_nullConfig_constructsSuccessfully() {
+        CxHostnameVerifier verifier = new CxHostnameVerifier(null);
+        assertNotNull(verifier);
+    }
+
+    @Test
+    public void verify_emptyConfig_constructsSuccessfully() {
+        CxHostnameVerifier verifier = new CxHostnameVerifier("");
+        assertNotNull(verifier);
+    }
+}


### PR DESCRIPTION
  Implement CxHostnameVerifier with multi-level fallback chain:
  CN/SAN validation, config property (ssl.allowed.hosts),
  and CX_ALLOWED_HOSTS environment variable. Add CX_HOSTNAME_VERIFICATION_ENABLED
  flag to enable/disable verification. Defaults to disabled for backward compatibility.